### PR TITLE
Support new directory structure of Terraform v0.13.x in make sideload task

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -10,6 +10,8 @@ BIN_PATH=${DIST_DIR}/${BIN_NAME}
 GO111MODULE=on
 
 PLUGINS_DIR=~/.terraform.d/plugins
+PLUGIN_PATH=onelogin.com/onelogin/onelogin
+VERSION=0.1.0
 
 clean:
 	rm -r ${DIST_DIR}
@@ -23,8 +25,16 @@ build:
 	go build -o ${DIST_DIR} ./...
 
 sideload: build
+	# Terraform v0.12.x
 	mkdir -p ${PLUGINS_DIR}
 	cp ${BIN_PATH} ${PLUGINS_DIR}/${BIN_NAME}
+	# Terraform >= v0.13.x
+	# macOS
+	mkdir -p ${PLUGINS_DIR}/${PLUGIN_PATH}/${VERSION}/darwin_amd64
+	cp ${BIN_PATH} ${PLUGINS_DIR}/${PLUGIN_PATH}/${VERSION}/darwin_amd64/${BIN_NAME}
+	# Linux
+	mkdir -p ${PLUGINS_DIR}/${PLUGIN_PATH}/${VERSION}/linux_amd64
+	cp ${BIN_PATH} ${PLUGINS_DIR}/${PLUGIN_PATH}/${VERSION}/linux_amd64/${BIN_NAME}
 
 testacc:
 	TF_ACC=1 go test ./... -v -timeout 120m

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you are sideloading this provider (i.e. not getting this via the Terraform st
     make sideload
     ```
 
-If you are using Terraform v0.13.x or later you can use following Terraform configuration for sideloaded version of this provider:
+    If you are using Terraform v0.13.x or later you can use following Terraform configuration for sideloaded version of this provider:
     ```
     terraform {
       required_providers {

--- a/README.md
+++ b/README.md
@@ -14,6 +14,23 @@ If you are sideloading this provider (i.e. not getting this via the Terraform st
     ```
     make sideload
     ```
+
+If you are using Terraform v0.13.x or later you can use following Terraform configuration for sideloaded version of this provider:
+    ```
+    terraform {
+      required_providers {
+        onelogin = {
+          source  = "onelogin.com/onelogin/onelogin"
+          version = "0.1.0"
+        }
+      }
+    }
+
+    provider "onelogin" {
+      # Configuration options
+    }
+    ```
+
 2) You'll need admin access to a OneLogin account where you can create API credentials. Create a set of API credentials with _manage all_ permission. For applying the credentials, there are 2 ways
 
     * Export these credentials to your environment and the provider will read them in from there


### PR DESCRIPTION
Terraform v0.13.x introduces new directory structure for plugins

https://www.hashicorp.com/blog/automatic-installation-of-third-party-providers-with-terraform-0-13
> Terraform needs a way to tell providers on disk apart— binary name is no longer sufficient—so we've created a new directory hierarchy that Terraform can use to precisely determine the source address of each provider it finds on disk:
>
> `$PLUGIN_DIRECTORY/$SOURCEHOSTNAME/$SOURCENAMESPACE/$NAME/$VERSION/$OS_$ARCH/`

This pull request introduces changes to `make sideload` task. It copies a binary to three locations: the old one and two new ones for different architectures. I didn't introduce any extra logic to detect version of Terraform or operating system.