### PR TITLE
Improve docs for user resource and change email to required field

### DIFF
--- a/docs/resources/onelogin_user.md
+++ b/docs/resources/onelogin_user.md
@@ -68,12 +68,14 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-No further attributes are exported
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The user's id
 
 ## Import
 
-A User can be imported via the OneLogin User.
+A User can be imported via the OneLogin User ID.
 
 ```
-$ terraform import onelogin_users.example <user_id>
+$ terraform import onelogin_users.example 12345678
 ```

--- a/ol_schema/user/user.go
+++ b/ol_schema/user/user.go
@@ -16,7 +16,7 @@ func Schema() map[string]*schema.Schema {
 		},
 		"email": &schema.Schema{
 			Type:     schema.TypeString,
-			Optional: true,
+			Required: true,
 		},
 		"firstname": &schema.Schema{
 			Type:     schema.TypeString,


### PR DESCRIPTION
On page https://registry.terraform.io/providers/onelogin/onelogin/latest/docs/resources/onelogin_user
I noticed that `<user_id>` is not generated, so in this PR I'm changing it to numerical example `12345678`

![image](https://user-images.githubusercontent.com/373530/96335879-fa391980-107b-11eb-8bfd-350d915fd231.png)

I also noticed that according to [provider documentation](https://registry.terraform.io/providers/onelogin/onelogin/latest/docs/resources/onelogin_user) and [api documentation](https://developers.onelogin.com/api-docs/2/users/create-user)  `email` is required field, so I'm changing it in the provider code.
