### PR TITLE
Modify type of role 

### DIFF
--- a/ol_schema/role/role.go
+++ b/ol_schema/role/role.go
@@ -16,17 +16,17 @@ func Schema() map[string]*schema.Schema {
 			Required: true,
 		},
 		"apps": &schema.Schema{
-			Type:     schema.TypeList,
+			Type:     schema.TypeSet,
 			Required: true,
 			Elem:     &schema.Schema{Type: schema.TypeInt},
 		},
 		"users": &schema.Schema{
-			Type:     schema.TypeList,
+			Type:     schema.TypeSet,
 			Required: true,
 			Elem:     &schema.Schema{Type: schema.TypeInt},
 		},
 		"admins": &schema.Schema{
-			Type:     schema.TypeList,
+			Type:     schema.TypeSet,
 			Required: true,
 			Elem:     &schema.Schema{Type: schema.TypeInt},
 		},


### PR DESCRIPTION
## Problem

`terraform plan` detects differences on the list just showing item order, which makes no effect actually. 

Example
```shell
  # module.developer.onelogin_roles.role will be updated in-place
  ~ resource "onelogin_roles" "role" {
      ~ admins = [
          - 34873631,
            34873695,
          + 34873631,
        ]
        apps   = [
            698140,
```

## Solution

According to [official reference](https://www.terraform.io/docs/extend/schemas/schema-types.html),  schema.TypeList represents ` an ordered collection of items`. 

On the other hand, TypeSet is for `used to represent an unordered collection of items,`. It seems better for Role. 


Is there any problem to change types of them? 

