### PR TITLE
Add missing '=' to docs and examples

### DIFF
--- a/docs/resources/onelogin_app.md
+++ b/docs/resources/onelogin_app.md
@@ -23,11 +23,11 @@ resource onelogin_apps my_app {
   visible = true
   allow_assumed_signin = false
 
-  provisioning {
+  provisioning = {
     enabled = false
   }
 
-	parameters {
+	parameters = {
 		safe_entitlements_enabled = false
 		user_attribute_mappings = ""
 		provisioned_entitlements = false

--- a/docs/resources/onelogin_app_rule.md
+++ b/docs/resources/onelogin_app_rule.md
@@ -21,12 +21,12 @@ resource onelogin_app_rules check{
   enabled = true
   match = "all"
   name = "first rule"
-  conditions {
+  conditions = {
     operator = "ri"
     source = "has_role"
     value = "340475"
   }
-  actions {
+  actions = {
     action = "set_amazonusername"
     expression = ".*"
     value = ["member_of"]
@@ -42,12 +42,12 @@ resource onelogin_app_rules test{
   enabled = true
   match = "all"
   name = "first rule"
-  conditions {
+  conditions = {
     operator = "ri"
     source = "has_role"
     value = "340475"
   }
-  actions {
+  actions = {
     action = "set_amazonusername"
     expression = ".*"
     value = ["member_of"]
@@ -60,12 +60,12 @@ resource onelogin_app_rules check{
   enabled = true
   match = "all"
   name = "second rule"
-  conditions {
+  conditions = {
     operator = "ri"
     source = "has_role"
     value = "340475"
   }
-  actions {
+  actions = {
     action = "set_amazonusername"
     expression = ".*"
     value = ["member_of"]

--- a/docs/resources/onelogin_auth_server.md
+++ b/docs/resources/onelogin_auth_server.md
@@ -18,7 +18,7 @@ This resource allows you to create and configure an Authentication Server.
 resource onelogin_auth_servers example {
   name = "Contacts API"
   description = "This is an api"
-  configuration {
+  configuration = {
     resource_identifier = "https://example.com/contacts"
     audiences = ["https://example.com/contacts"]
     refresh_token_expiration_minutes = 30

--- a/docs/resources/onelogin_oidc_app.md
+++ b/docs/resources/onelogin_oidc_app.md
@@ -23,7 +23,7 @@ resource onelogin_oidc_apps my_oidc_app {
 	connector_id = 123456
 	description = "example OIDC app"
 
-	configuration {
+	configuration = {
 		login_url = "https://www.example.com"
 		oidc_application_type = 0
 		redirect_uri = "https://example.com/example"
@@ -32,11 +32,11 @@ resource onelogin_oidc_apps my_oidc_app {
 		access_token_expiration_minutes = 1
 	}
 
-	provisioning {
+	provisioning = {
 		enabled = false
 	}
 
-	parameters {
+	parameters = {
 		provisioned_entitlements = false
 		user_attribute_macros = ""
 		user_attribute_mappings = ""

--- a/docs/resources/onelogin_saml_app.md
+++ b/docs/resources/onelogin_saml_app.md
@@ -23,7 +23,7 @@ resource onelogin_saml_apps example_saml_app {
   name = "Example App"
   notes = "example saml app"
 
-  parameters {
+  parameters = {
     include_in_saml_assertion = false
     provisioned_entitlements = false
     user_attribute_macros = ""
@@ -37,12 +37,12 @@ resource onelogin_saml_apps example_saml_app {
     default_values = ""
   }
 
-  configuration {
+  configuration = {
     signature_algorithm = "SHA-1"
     provider_arn = "example_arn"
   }
 
-  provisioning {
+  provisioning = {
     enabled = false
   }
 }

--- a/docs/resources/onelogin_user_mapping.md
+++ b/docs/resources/onelogin_user_mapping.md
@@ -21,12 +21,12 @@ resource onelogin_user_mappings example {
   match = "all"
   position = 1
 
-  actions {
+  actions = {
     value = ["1"]
     action = "set_status"
   }
 
-  conditions {
+  conditions = {
     operator = ">"
     source = "last_login"
     value = "90"

--- a/examples/onelogin_app_rules_example.tf
+++ b/examples/onelogin_app_rules_example.tf
@@ -13,12 +13,12 @@ resource onelogin_app_rules test{
   enabled = true
   match = "all"
   name = "first rule"
-  conditions {
+  conditions = {
     operator = ">"
     source = "last_login"
     value = "90"
   }
-  actions {
+  actions = {
     action = "set_amazonusername"
     expression = ".*"
     value = ["member_of"]
@@ -29,12 +29,12 @@ resource onelogin_app_rules check{
   enabled = true
   match = "all"
   name = "second rule"
-  conditions {
+  conditions = {
     operator = "ri"
     source = "has_role"
     value = "340475"
   }
-  actions {
+  actions = {
     action = "set_amazonusername"
     expression = ".*"
     value = ["member_of"]

--- a/examples/onelogin_app_rules_updated_example.tf
+++ b/examples/onelogin_app_rules_updated_example.tf
@@ -13,12 +13,12 @@ resource onelogin_app_rules test{
   enabled = true
   match = "all"
   name = "updated first rule"
-  conditions {
+  conditions = {
     operator = "<"
     source = "last_login"
     value = "90"
   }
-  actions {
+  actions = {
     action = "set_amazonusername"
     expression = ".*"
     value = ["member_of"]
@@ -29,12 +29,12 @@ resource onelogin_app_rules check{
   enabled = true
   match = "all"
   name = "updated second rule"
-  conditions {
+  conditions = {
     operator = "ri"
     source = "has_role"
     value = "340475"
   }
-  actions {
+  actions = {
     action = "set_amazonusername"
     expression = ".*"
     value = ["member_of"]

--- a/examples/onelogin_auth_server_example.tf
+++ b/examples/onelogin_auth_server_example.tf
@@ -1,7 +1,7 @@
 resource onelogin_auth_servers test {
   name = "test"
   description = "test"
-  configuration {
+  configuration = {
     resource_identifier = "https://example.com/contacts"
     audiences = ["https://example.com/contacts"]
     refresh_token_expiration_minutes = 30

--- a/examples/onelogin_auth_server_updated_example.tf
+++ b/examples/onelogin_auth_server_updated_example.tf
@@ -1,7 +1,7 @@
 resource onelogin_auth_servers test {
   name = "updated"
   description = "updated test"
-  configuration {
+  configuration = {
     resource_identifier = "https://example.com/users/contacts"
     audiences = ["https://example.com/contacts", "https://example.com/users/contacts"]
     refresh_token_expiration_minutes = 30

--- a/examples/onelogin_user_mapping_example.tf
+++ b/examples/onelogin_user_mapping_example.tf
@@ -4,12 +4,12 @@ resource onelogin_user_mappings basic_test {
   match = "all"
   position = 1
 
-  actions {
+  actions = {
     value = ["1"]
     action = "set_status"
   }
 
-  conditions {
+  conditions = {
     operator = ">"
     source = "last_login"
     value = "90"

--- a/examples/onelogin_user_mapping_updated_example.tf
+++ b/examples/onelogin_user_mapping_updated_example.tf
@@ -4,12 +4,12 @@ resource onelogin_user_mappings basic_test {
   match = "all"
   position = 1
 
-  actions {
+  actions = {
     value = ["2"]
     action = "set_status"
   }
 
-  conditions {
+  conditions = {
     operator = ">"
     source = "last_login"
     value = "120"


### PR DESCRIPTION
Closes #39 by adding the missing '=' via sed, ie:

`sed -i '/resource.*{/!s/\([a-z+]\) {/\1 = {/' *.tf`
