### PR TITLE
Add idp configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/fatih/color v1.10.0 // indirect
 	github.com/hashicorp/terraform v0.12.24
 	github.com/hashicorp/terraform-plugin-sdk v1.9.1
-	github.com/onelogin/onelogin-go-sdk v1.0.14
+	github.com/onelogin/onelogin-go-sdk v1.0.15
 	github.com/stretchr/testify v1.5.1
 	golang.org/x/image v0.0.0-20201208152932-35266b937fa6 // indirect
 	golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78 // indirect

--- a/ol_schema/app/configuration/configuration.go
+++ b/ol_schema/app/configuration/configuration.go
@@ -54,6 +54,7 @@ func Inflate(s map[string]interface{}) (apps.AppConfiguration, error) {
 	out.RedirectURI = getOlString(s["redirect_uri"])
 	out.LoginURL = getOlString(s["login_url"])
 	out.ProviderArn = getOlString(s["provider_arn"])
+	out.IdpList = getOlString(s["idp_list"])
 	out.SignatureAlgorithm = getOlString(s["signature_algorithm"])
 	out.LogoutURL = getOlString(s["logout_url"])
 	out.Audience = getOlString(s["audience"])
@@ -144,6 +145,10 @@ func FlattenSAML(config apps.AppConfiguration) map[string]interface{} {
 	if config.ProviderArn != nil {
 		tfOut["provider_arn"] = *config.ProviderArn
 	}
+	if config.IdpList != nil {
+		tfOut["idp_list"] = *config.IdpList
+	}
+
 	if config.SignatureAlgorithm != nil {
 		tfOut["signature_algorithm"] = *config.SignatureAlgorithm
 	}

--- a/ol_schema/app/configuration/configuration_test.go
+++ b/ol_schema/app/configuration/configuration_test.go
@@ -82,21 +82,25 @@ func TestInflateConfiguration(t *testing.T) {
 			ResourceData: map[string]interface{}{
 				"provider_arn":        "test",
 				"signature_algorithm": "test",
+				"idp_list":            "test",
 			},
 			ExpectedOutput: apps.AppConfiguration{
 				ProviderArn:        oltypes.String("test"),
 				SignatureAlgorithm: oltypes.String("test"),
+				IdpList:            oltypes.String("test"),
 			},
 		},
 		"creates and returns the address of an AppConfiguration struct for a SAML app with exra fields": {
 			ResourceData: map[string]interface{}{
 				"provider_arn":        "test",
 				"signature_algorithm": "test",
+				"idp_list":            "test",
 				"encrypt_assertion":   "1",
 			},
 			ExpectedOutput: apps.AppConfiguration{
 				ProviderArn:        oltypes.String("test"),
 				SignatureAlgorithm: oltypes.String("test"),
+				IdpList:            oltypes.String("test"),
 				EncryptAssertion:   oltypes.String("1"),
 			},
 		},
@@ -155,10 +159,12 @@ func TestFlattenSAMLConfiguration(t *testing.T) {
 			InputData: apps.AppConfiguration{
 				ProviderArn:        oltypes.String("test"),
 				SignatureAlgorithm: oltypes.String("test"),
+				IdpList:            oltypes.String("test"),
 			},
 			ExpectedOutput: map[string]interface{}{
 				"provider_arn":        "test",
 				"signature_algorithm": "test",
+				"idp_list":            "test",
 			},
 		},
 	}


### PR DESCRIPTION
* This pr add support of idp configuration for, such as AWS saml app
* example
```
locals {
  aws_idp_list = <<-EDT
    arn:aws:iam::xxxxx:saml-provider/OneLogin
    arn:aws:iam::yyyyy:saml-provider/OneLogin
  EDT
}

resource onelogin_saml_apps example_saml_app {
  connector_id = xxx
  name = "Amazon Web Services (AWS) Multi Account"

  configuration = {
    signature_algorithm = "SHA-1"
    idp_list = local.aws_idp_list
  }
}
```
