### PR TITLE
Change the type of rule value

### DIFF
--- a/ol_schema/rules/actions/actions.go
+++ b/ol_schema/rules/actions/actions.go
@@ -18,7 +18,7 @@ func Schema() map[string]*schema.Schema {
 			Optional: true,
 		},
 		"value": &schema.Schema{
-			Type:     schema.TypeList,
+			Type:     schema.TypeSet,
 			Required: true,
 			Elem: &schema.Schema{
 				Type: schema.TypeString,


### PR DESCRIPTION
Because the type of value is  'TypeList',  terraform recognize reordering as a change. 
See also  #32 , which is almost same to this PR

Example. 
```
  ~ resource "onelogin_app_rules" "rule" {
        # (4 unchanged attributes hidden)

      ~ actions {
          ~ value  = [
              - "arn:aws:iam::xxxxx:role/admin",   # <- same
                "arn:aws:iam::yyyyy:role/test1",
              + "arn:aws:iam::xxxxx:role/admin",  # <- same
                "arn:aws:iam::yyyyy:role/test2",
            ]
            # (1 unchanged attribute hidden)
        }
```