### PR TITLE
DEVEX-865: Fix position for user mappings and app rules.

### DIFF
--- a/docs/resources/onelogin_app_rule.md
+++ b/docs/resources/onelogin_app_rule.md
@@ -95,7 +95,7 @@ The following arguments are supported:
 
 * `name` - (Required) The Rule's name
 
-* `position` - (Required) Indicates the order of the rule. When `null` this will default to last position.
+* `position` - (Optional) Indicates the ordering of the rule. When not supplied the rule will be put at the end of the list on create and managed by the provider. '0' can be supplied to consistently push this rule to the end of the list on every update.
 
 * `conditions` - (Required) An array of conditions that the user must meet in order for the rule to be applied.
   * `source` - The source field to check. See [List Conditions](https://developers.onelogin.com/api-docs/2/app-rules/list-conditions) for possible values.

--- a/docs/resources/onelogin_user_mapping.md
+++ b/docs/resources/onelogin_user_mapping.md
@@ -43,7 +43,7 @@ The following arguments are supported:
 
 * `match` - (Required) Indicates how conditions should be matched. Must be one of `all` or `any`.
 
-* `position` - (Required) Indicates the ordering of the mapping. When `null` this will be placed last.
+* `position` - (Optional) Indicates the ordering of the mapping. When not supplied the mapping will be put at the end of the list on create and managed by the provider. '0' can be supplied to consistently push this mapping to the end of the list on every update.
 
 * `conditions` - (Required) An array of conditions that the user must meet in order for the mapping to be applied.
   * `source` - (Required) The source field to check. See [List Conditions](https://developers.onelogin.com/api-docs/2/user-mappings/list-conditions) for possible values.

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-config-inspect v0.0.0-20191212124732-c6ae6269b9d7 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.9.1
 	github.com/mattn/go-isatty v0.0.13 // indirect
-	github.com/onelogin/onelogin-go-sdk v1.1.18
+	github.com/onelogin/onelogin-go-sdk v1.1.20
 	github.com/stretchr/testify v1.5.1
 	golang.org/x/sys v0.0.0-20210608053332-aa57babbf139 // indirect
 	golang.org/x/text v0.3.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -205,6 +205,8 @@ github.com/onelogin/onelogin-go-sdk v1.1.13 h1:0G5T/uEi5AvulfC8F42tIYVe94RKcSWia
 github.com/onelogin/onelogin-go-sdk v1.1.13/go.mod h1:GM0+ziS1fhnPnxC2fLzVloxn+VzBwzXKkIaDOPoE5GU=
 github.com/onelogin/onelogin-go-sdk v1.1.18 h1:FrL9BLQkmYEhKZatPX307kCLtXz7SBT3G7+E0OBh+C4=
 github.com/onelogin/onelogin-go-sdk v1.1.18/go.mod h1:GM0+ziS1fhnPnxC2fLzVloxn+VzBwzXKkIaDOPoE5GU=
+github.com/onelogin/onelogin-go-sdk v1.1.20 h1:E3cIyZ9q9DNLv0PtFRT/d7BQtaiaiCpIfGdCgzLB6FU=
+github.com/onelogin/onelogin-go-sdk v1.1.20/go.mod h1:GM0+ziS1fhnPnxC2fLzVloxn+VzBwzXKkIaDOPoE5GU=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.0 h1:Iw5WCbBcaAAd0fpRb1c9r5YCylv4XDoCSigm1zLevwU=
 github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=

--- a/ol_schema/rules/rules.go
+++ b/ol_schema/rules/rules.go
@@ -14,37 +14,37 @@ import (
 // Schema returns a key/value map of the various fields that make up the Rules of a OneLogin App.
 func Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"app_id": &schema.Schema{
+		"app_id": {
 			Type:     schema.TypeString,
 			Required: true,
 		},
-		"name": &schema.Schema{
+		"name": {
 			Type:     schema.TypeString,
 			Required: true,
 		},
-		"match": &schema.Schema{
+		"match": {
 			Type:         schema.TypeString,
 			Required:     true,
 			ValidateFunc: validMatch,
 		},
-		"enabled": &schema.Schema{
+		"enabled": {
 			Type:     schema.TypeBool,
 			Optional: true,
 			Default:  false,
 		},
-		"position": &schema.Schema{
+		"position": {
 			Type:     schema.TypeInt,
 			Optional: true,
 			Computed: true,
 		},
-		"conditions": &schema.Schema{
+		"conditions": {
 			Type:     schema.TypeList,
 			Optional: true,
 			Elem: &schema.Resource{
 				Schema: appruleconditionsschema.Schema(),
 			},
 		},
-		"actions": &schema.Schema{
+		"actions": {
 			Type:     schema.TypeList,
 			Optional: true,
 			Elem: &schema.Resource{

--- a/ol_schema/rules/rules_test.go
+++ b/ol_schema/rules/rules_test.go
@@ -62,14 +62,59 @@ func TestInflate(t *testing.T) {
 				Enabled:  oltypes.Bool(true),
 				Position: oltypes.Int32(int32(1)),
 				Conditions: []apprules.AppRuleConditions{
-					apprules.AppRuleConditions{
+					{
 						Source:   oltypes.String("test"),
 						Operator: oltypes.String("="),
 						Value:    oltypes.String("test"),
 					},
 				},
 				Actions: []apprules.AppRuleActions{
-					apprules.AppRuleActions{
+					{
+						Action:     oltypes.String("test"),
+						Expression: oltypes.String(".*"),
+						Value:      []string{"test"},
+					},
+				},
+			},
+		},
+		"handles a rule without the position provided": {
+			ResourceData: map[string]interface{}{
+				"id":      "123",
+				"app_id":  "123",
+				"name":    "test",
+				"match":   "test",
+				"enabled": true,
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"source":   "test",
+						"operator": "=",
+						"value":    "test",
+					},
+				},
+				"actions": []interface{}{
+					map[string]interface{}{
+						"action":     "test",
+						"expression": ".*",
+						"value":      schema.NewSet(mockSetFn, []interface{}{"test"}),
+					},
+				},
+			},
+			ExpectedOutput: apprules.AppRule{
+				ID:       oltypes.Int32(int32(123)),
+				AppID:    oltypes.Int32(int32(123)),
+				Name:     oltypes.String("test"),
+				Match:    oltypes.String("test"),
+				Enabled:  oltypes.Bool(true),
+				Position: nil,
+				Conditions: []apprules.AppRuleConditions{
+					{
+						Source:   oltypes.String("test"),
+						Operator: oltypes.String("="),
+						Value:    oltypes.String("test"),
+					},
+				},
+				Actions: []apprules.AppRuleActions{
+					{
 						Action:     oltypes.String("test"),
 						Expression: oltypes.String(".*"),
 						Value:      []string{"test"},

--- a/ol_schema/user_mapping/user_mapping.go
+++ b/ol_schema/user_mapping/user_mapping.go
@@ -1,44 +1,46 @@
 package usermappingschema
 
 import (
+	"strconv"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/onelogin/onelogin-go-sdk/pkg/oltypes"
-	"github.com/onelogin/onelogin-go-sdk/pkg/services/user_mappings"
-	"github.com/onelogin/terraform-provider-onelogin/ol_schema/user_mapping/actions"
-	"github.com/onelogin/terraform-provider-onelogin/ol_schema/user_mapping/conditions"
+	usermappings "github.com/onelogin/onelogin-go-sdk/pkg/services/user_mappings"
+	usermappingactionsschema "github.com/onelogin/terraform-provider-onelogin/ol_schema/user_mapping/actions"
+	usermappingconditionsschema "github.com/onelogin/terraform-provider-onelogin/ol_schema/user_mapping/conditions"
 	"github.com/onelogin/terraform-provider-onelogin/utils"
-	"strconv"
 )
 
 // Schema returns a key/value map of the various fields that make up the Rules of a OneLogin UserMapping.
 func Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"name": &schema.Schema{
+		"name": {
 			Type:     schema.TypeString,
 			Required: true,
 		},
-		"match": &schema.Schema{
+		"match": {
 			Type:         schema.TypeString,
 			Required:     true,
 			ValidateFunc: validMatch,
 		},
-		"enabled": &schema.Schema{
+		"enabled": {
 			Type:     schema.TypeBool,
 			Optional: true,
 			Default:  false,
 		},
-		"position": &schema.Schema{
+		"position": {
 			Type:     schema.TypeInt,
-			Required: true,
+			Optional: true,
+			Computed: true,
 		},
-		"conditions": &schema.Schema{
+		"conditions": {
 			Type:     schema.TypeList,
 			Optional: true,
 			Elem: &schema.Resource{
 				Schema: usermappingconditionsschema.Schema(),
 			},
 		},
-		"actions": &schema.Schema{
+		"actions": {
 			Type:     schema.TypeList,
 			Optional: true,
 			Elem: &schema.Resource{

--- a/ol_schema/user_mapping/user_mapping_test.go
+++ b/ol_schema/user_mapping/user_mapping_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/onelogin/onelogin-go-sdk/pkg/oltypes"
-	"github.com/onelogin/onelogin-go-sdk/pkg/services/user_mappings"
+	usermappings "github.com/onelogin/onelogin-go-sdk/pkg/services/user_mappings"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -54,14 +54,56 @@ func TestInflate(t *testing.T) {
 				Enabled:  oltypes.Bool(true),
 				Position: oltypes.Int32(int32(1)),
 				Conditions: []usermappings.UserMappingConditions{
-					usermappings.UserMappingConditions{
+					{
 						Source:   oltypes.String("test"),
 						Operator: oltypes.String("="),
 						Value:    oltypes.String("test"),
 					},
 				},
 				Actions: []usermappings.UserMappingActions{
-					usermappings.UserMappingActions{
+					{
+						Action: oltypes.String("test"),
+						Value:  []string{"test"},
+					},
+				},
+			},
+		},
+		"handles a user mapping without the position provided": {
+			ResourceData: map[string]interface{}{
+				"id":      "123",
+				"name":    "test",
+				"match":   "test",
+				"enabled": true,
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"source":   "test",
+						"operator": "=",
+						"value":    "test",
+					},
+				},
+				"actions": []interface{}{
+					map[string]interface{}{
+						"action":     "test",
+						"expression": ".*",
+						"value":      []interface{}{"test"},
+					},
+				},
+			},
+			ExpectedOutput: usermappings.UserMapping{
+				ID:       oltypes.Int32(int32(123)),
+				Name:     oltypes.String("test"),
+				Match:    oltypes.String("test"),
+				Enabled:  oltypes.Bool(true),
+				Position: nil,
+				Conditions: []usermappings.UserMappingConditions{
+					{
+						Source:   oltypes.String("test"),
+						Operator: oltypes.String("="),
+						Value:    oltypes.String("test"),
+					},
+				},
+				Actions: []usermappings.UserMappingActions{
+					{
 						Action: oltypes.String("test"),
 						Value:  []string{"test"},
 					},
@@ -80,41 +122,41 @@ func TestInflate(t *testing.T) {
 func TestFlatten(t *testing.T) {
 	t.Run("It flattens the user mapping Struct", func(t *testing.T) {
 		UserMappingStruct := []usermappings.UserMapping{
-			usermappings.UserMapping{
+			{
 				ID:       oltypes.Int32(int32(123)),
 				Name:     oltypes.String("test"),
 				Match:    oltypes.String("test"),
 				Enabled:  oltypes.Bool(true),
 				Position: oltypes.Int32(int32(1)),
 				Conditions: []usermappings.UserMappingConditions{
-					usermappings.UserMappingConditions{
+					{
 						Source:   oltypes.String("test"),
 						Operator: oltypes.String("="),
 						Value:    oltypes.String("test"),
 					},
 				},
 				Actions: []usermappings.UserMappingActions{
-					usermappings.UserMappingActions{
+					{
 						Action: oltypes.String("test"),
 						Value:  []string{"test"},
 					},
 				},
 			},
-			usermappings.UserMapping{
+			{
 				ID:       oltypes.Int32(int32(456)),
 				Name:     oltypes.String("test2"),
 				Match:    oltypes.String("test2"),
 				Enabled:  oltypes.Bool(true),
 				Position: oltypes.Int32(int32(2)),
 				Conditions: []usermappings.UserMappingConditions{
-					usermappings.UserMappingConditions{
+					{
 						Source:   oltypes.String("test2"),
 						Operator: oltypes.String(">"),
 						Value:    oltypes.String("test2"),
 					},
 				},
 				Actions: []usermappings.UserMappingActions{
-					usermappings.UserMappingActions{
+					{
 						Action: oltypes.String("test2"),
 						Value:  []string{"test2"},
 					},
@@ -123,41 +165,41 @@ func TestFlatten(t *testing.T) {
 		}
 		subj := Flatten(UserMappingStruct)
 		expected := []map[string]interface{}{
-			map[string]interface{}{
+			{
 				"id":       oltypes.Int32(int32(123)),
 				"name":     oltypes.String("test"),
 				"match":    oltypes.String("test"),
 				"enabled":  oltypes.Bool(true),
 				"position": oltypes.Int32(int32(1)),
 				"conditions": []map[string]interface{}{
-					map[string]interface{}{
+					{
 						"source":   oltypes.String("test"),
 						"operator": oltypes.String("="),
 						"value":    oltypes.String("test"),
 					},
 				},
 				"actions": []map[string]interface{}{
-					map[string]interface{}{
+					{
 						"action": oltypes.String("test"),
 						"value":  []string{"test"},
 					},
 				},
 			},
-			map[string]interface{}{
+			{
 				"id":       oltypes.Int32(int32(456)),
 				"name":     oltypes.String("test2"),
 				"match":    oltypes.String("test2"),
 				"enabled":  oltypes.Bool(true),
 				"position": oltypes.Int32(int32(2)),
 				"conditions": []map[string]interface{}{
-					map[string]interface{}{
+					{
 						"source":   oltypes.String("test2"),
 						"operator": oltypes.String(">"),
 						"value":    oltypes.String("test2"),
 					},
 				},
 				"actions": []map[string]interface{}{
-					map[string]interface{}{
+					{
 						"action": oltypes.String("test2"),
 						"value":  []string{"test2"},
 					},


### PR DESCRIPTION
This makes the user mappings `position` value optional and computed, so that the scripts don't have to define it. The documentation of user mappings and app rules `position` property to match what happens.

Additionally updated the onelogin-go-sdk version to the latest.