### PR TITLE
Add workaround for app rules action with no expression.

### DIFF
--- a/ol_schema/rules/actions/actions.go
+++ b/ol_schema/rules/actions/actions.go
@@ -1,6 +1,9 @@
 package appruleactionsschema
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/onelogin/onelogin-go-sdk/pkg/oltypes"
 	apprules "github.com/onelogin/onelogin-go-sdk/pkg/services/apps/app_rules"

--- a/ol_schema/rules/actions/actions.go
+++ b/ol_schema/rules/actions/actions.go
@@ -6,6 +6,8 @@ import (
 	apprules "github.com/onelogin/onelogin-go-sdk/pkg/services/apps/app_rules"
 )
 
+const NO_EXPRESSION_SUFFIX = "_from_existing"
+
 // Schema returns a key/value map of the various fields that make up the Actions of a OneLogin Rule.
 func Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
@@ -32,8 +34,8 @@ func Schema() map[string]*schema.Schema {
 func Inflate(s map[string]interface{}) apprules.AppRuleActions {
 	out := apprules.AppRuleActions{}
 	if act, notNil := s["action"].(string); notNil {
-		if act == "set_role_from_existing" {
-			act = "set_role"
+		if strings.HasSuffix(act, NO_EXPRESSION_SUFFIX) {
+			act = strings.TrimSuffix(act, NO_EXPRESSION_SUFFIX)
 			out.Expression = nil
 		} else {
 			if exp, notNil := s["expression"].(string); notNil {
@@ -56,9 +58,9 @@ func Inflate(s map[string]interface{}) apprules.AppRuleActions {
 func Flatten(acts []apprules.AppRuleActions) []map[string]interface{} {
 	out := make([]map[string]interface{}, len(acts))
 	for i, action := range acts {
-		if action.Expression == nil && *action.Action == "set_role" {
+		if action.Expression == nil && action.Action != nil {
 			out[i] = map[string]interface{}{
-				"action":     "set_role_from_existing",
+				"action":     fmt.Sprintf("%s%s", *action.Action, NO_EXPRESSION_SUFFIX),
 				"expression": action.Expression,
 				"value":      action.Value,
 			}


### PR DESCRIPTION
Closes #70 

Updated the workaround app rules actions that don't define an expression to be able to have them set as null by adding `_from_existing` to the end.