### PR TITLE
Add new resource type to enable user role attachment

### DIFF
--- a/onelogin/provider.go
+++ b/onelogin/provider.go
@@ -52,6 +52,7 @@ func Provider() *schema.Provider {
 			"onelogin_app_rules":                       AppRules(),
 			"onelogin_user_mappings":                   UserMappings(),
 			"onelogin_users":                           Users(),
+			"onelogin_user_role_attachments":           UserRoleAttachment(),
 			"onelogin_auth_servers":                    AuthServers(),
 			"onelogin_roles":                           Roles(),
 			"onelogin_smarthooks":                      SmartHooks(),

--- a/onelogin/resource_onelogin_user_role_attachments.go
+++ b/onelogin/resource_onelogin_user_role_attachments.go
@@ -72,10 +72,8 @@ func userRoleAttachmentUpdate(d *schema.ResourceData, m interface{}) error {
 	oldUsers, newUsers:= d.GetChange("users")
 
 	var err error
-  if oldRole != newRole || newUsers.(*schema.Set).Len() == 0 {
-    if err = removeUserRoleAttachment(client, oldUsers, oldRole); err != nil {
+  if err = removeUserRoleAttachment(client, oldUsers, oldRole); err != nil {
 		  return fmt.Errorf("Unable to delete mapping %s", err)
-    }
   }
 
 	if err = updateUserRoleAttachment(client, newUsers, newRole); err != nil {
@@ -102,7 +100,7 @@ func userRoleAttachmentDelete(d *schema.ResourceData, m interface{}) error {
 
 func updateUserRoleAttachment(client *client.APIClient, userIDs interface{}, roleID interface{}) error {
   /*
-  must be replaced with onelogin-go-sdk after sdk v3 is released
+    should be replaced with method provided by onelogin-go-sdk after sdk v3 is released
   */
   payload := make([]int32, userIDs.(*schema.Set).Len())
   for i, userID := range userIDs.(*schema.Set).List() {
@@ -121,10 +119,19 @@ func updateUserRoleAttachment(client *client.APIClient, userIDs interface{}, rol
 
 func removeUserRoleAttachment(client *client.APIClient, userIDs interface{}, roleID interface{}) error {
   /*
-    it is not implemented yet,
-    because onelogin-go-sdk doesn't support DELETE method with payload which is required by api spec
+    should be replaced with method provided by onelogin-go-sdk after sdk v3 is released
   */
+  payload := make([]int32, userIDs.(*schema.Set).Len())
+  for i, userID := range userIDs.(*schema.Set).List() {
+    payload[i] = int32(userID.(int))
+  }
 
-	return nil
+  svc := client.Services.RolesV1
+	_, err := svc.Repository.Destroy(olhttp.OLHTTPRequest{
+		URL:        fmt.Sprintf("%s/%d/users", svc.Endpoint, int32(roleID.(int))),
+		Headers:    map[string]string{"Content-Type": "application/json"},
+		AuthMethod: "bearer",
+		Payload:    &payload,
+	})
+	return err
 }
-

--- a/onelogin/resource_onelogin_user_role_attachments.go
+++ b/onelogin/resource_onelogin_user_role_attachments.go
@@ -36,7 +36,7 @@ func userRoleAttachmentCreate(d *schema.ResourceData, m interface{}) error {
 	roleID := d.Get("role_id")
 	users := d.Get("users")
 
-	if appErr := attachRoleToUser(client, users, roleID); appErr != nil {
+	if appErr := updateUserRoleAttachment(client, users, roleID); appErr != nil {
 		return fmt.Errorf("Unable to attach role to app %s", appErr)
 	}
 

--- a/onelogin/resource_onelogin_user_role_attachments.go
+++ b/onelogin/resource_onelogin_user_role_attachments.go
@@ -1,0 +1,130 @@
+package onelogin
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/onelogin/onelogin-go-sdk/pkg/client"
+)
+
+// UserRoleAttachment attaches additional configuration and sso schemas and
+// returns a resource with the CRUD methods and Terraform Schema defined
+func UserRoleAttachment() *schema.Resource {
+	return &schema.Resource{
+		Create: userRoleAttachmentCreate,
+		Read:   userRoleAttachmentRead,
+		Update: userRoleAttachmentUpdate,
+		Delete: userRoleAttachmentDelete,
+		Schema: map[string]*schema.Schema{
+			"role_id": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+  		"users": {
+  			Type:     schema.TypeSet,
+  			Required: true,
+  			Elem:     &schema.Schema{Type: schema.TypeInt},
+  		},
+		},
+	}
+}
+
+func userRoleAttachmentCreate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*client.APIClient)
+
+	roleID := d.Get("role_id")
+	users := d.Get("users")
+
+	if appErr := attachRoleToUser(client, users, roleID); appErr != nil {
+		return fmt.Errorf("Unable to attach role to app %s", appErr)
+	}
+
+	d.SetId(fmt.Sprintf("%d%d", roleID, users))
+	return userRoleAttachmentRead(d, m)
+}
+
+func userRoleAttachmentRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(*client.APIClient)
+	users := d.Get("users").(int)
+	roleID := d.Get("role_id").(int)
+
+	app, err := client.Services.AppsV2.GetOne(appID)
+	if err != nil {
+		d.SetId("")
+		return fmt.Errorf("App does not exist %s", err)
+	}
+	for _, rID := range app.RoleIDs {
+		if rID == roleID {
+			d.Set("role_id", rID)
+			d.Set("app_id", *app.ID)
+			return nil
+		}
+	}
+	d.SetId("")
+	return fmt.Errorf("App %d does not have role %d", appID, roleID)
+}
+
+func userRoleAttachmentUpdate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*client.APIClient)
+
+	oldApp, newApp := d.GetChange("app_id")
+	oldRole, newRole := d.GetChange("role_id")
+
+	var err error
+	if err = removeRoleFromUser(client, oldApp, oldRole); err != nil {
+		return fmt.Errorf("Unable to remove role from app %s", err)
+	}
+
+	if err = attachRoleToUser(client, newApp, newRole); err != nil {
+		return fmt.Errorf("Unable to attach role to app %s", err)
+	}
+
+	d.SetId(fmt.Sprintf("%d%d", newRole, newApp))
+	return userRoleAttachmentRead(d, m)
+}
+
+func userRoleAttachmentDelete(d *schema.ResourceData, m interface{}) error {
+	client := m.(*client.APIClient)
+
+	appID := d.Get("app_id")
+	roleID := d.Get("role_id")
+
+	var err error
+	if err = removeRoleFromUser(client, appID, roleID); err != nil {
+		return fmt.Errorf("Unable to remove role from app %s", err)
+	}
+	d.SetId("")
+	return nil
+}
+
+func removeRoleFromUser(client *client.APIClient, appID interface{}, roleID interface{}) error {
+	app, err := client.Services.AppsV2.GetOne(int32(appID.(int)))
+	if err != nil {
+		return err
+	}
+	newRoleIDs := make([]int, 0)
+	for _, rID := range app.RoleIDs {
+		if rID != roleID {
+			newRoleIDs = append(newRoleIDs, rID)
+		}
+	}
+	app.RoleIDs = newRoleIDs
+	app, err = client.Services.AppsV2.Update(app)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func attachRoleToUser(client *client.APIClient, appID interface{}, roleID interface{}) error {
+	app, err := client.Services.AppsV2.GetOne(int32(appID.(int)))
+	if err != nil {
+		return err
+	}
+	app.RoleIDs = append(app.RoleIDs, roleID.(int))
+	app, err = client.Services.AppsV2.Update(app)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/onelogin/resource_onelogin_user_role_attachments.go
+++ b/onelogin/resource_onelogin_user_role_attachments.go
@@ -22,11 +22,11 @@ func UserRoleAttachment() *schema.Resource {
 				Type:     schema.TypeInt,
 				Required: true,
 			},
-  		"users": {
-  			Type:     schema.TypeSet,
-  			Required: true,
-  			Elem:     &schema.Schema{Type: schema.TypeInt},
-  		},
+			"users": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeInt},
+			},
 		},
 	}
 }
@@ -68,13 +68,13 @@ func userRoleAttachmentRead(d *schema.ResourceData, m interface{}) error {
 func userRoleAttachmentUpdate(d *schema.ResourceData, m interface{}) error {
 	client := m.(*client.APIClient)
 
-	oldRole, newRole:= d.GetChange("role_id")
-	oldUsers, newUsers:= d.GetChange("users")
+	oldRole, newRole := d.GetChange("role_id")
+	oldUsers, newUsers := d.GetChange("users")
 
 	var err error
-  if err = removeUserRoleAttachment(client, oldUsers, oldRole); err != nil {
-		  return fmt.Errorf("Unable to delete mapping %s", err)
-  }
+	if err = removeUserRoleAttachment(client, oldUsers, oldRole); err != nil {
+		return fmt.Errorf("Unable to delete mapping %s", err)
+	}
 
 	if err = updateUserRoleAttachment(client, newUsers, newRole); err != nil {
 		return fmt.Errorf("Unable to update mapping %s", err)
@@ -99,15 +99,15 @@ func userRoleAttachmentDelete(d *schema.ResourceData, m interface{}) error {
 }
 
 func updateUserRoleAttachment(client *client.APIClient, userIDs interface{}, roleID interface{}) error {
-  /*
-    should be replaced with method provided by onelogin-go-sdk after sdk v3 is released
-  */
-  payload := make([]int32, userIDs.(*schema.Set).Len())
-  for i, userID := range userIDs.(*schema.Set).List() {
-    payload[i] = int32(userID.(int))
-  }
+	/*
+	   should be replaced with method provided by onelogin-go-sdk after sdk v3 is released
+	*/
+	payload := make([]int32, userIDs.(*schema.Set).Len())
+	for i, userID := range userIDs.(*schema.Set).List() {
+		payload[i] = int32(userID.(int))
+	}
 
-  svc := client.Services.RolesV1
+	svc := client.Services.RolesV1
 	_, err := svc.Repository.Create(olhttp.OLHTTPRequest{
 		URL:        fmt.Sprintf("%s/%d/users", svc.Endpoint, int32(roleID.(int))),
 		Headers:    map[string]string{"Content-Type": "application/json"},
@@ -118,15 +118,15 @@ func updateUserRoleAttachment(client *client.APIClient, userIDs interface{}, rol
 }
 
 func removeUserRoleAttachment(client *client.APIClient, userIDs interface{}, roleID interface{}) error {
-  /*
-    should be replaced with method provided by onelogin-go-sdk after sdk v3 is released
-  */
-  payload := make([]int32, userIDs.(*schema.Set).Len())
-  for i, userID := range userIDs.(*schema.Set).List() {
-    payload[i] = int32(userID.(int))
-  }
+	/*
+	   should be replaced with method provided by onelogin-go-sdk after sdk v3 is released
+	*/
+	payload := make([]int32, userIDs.(*schema.Set).Len())
+	for i, userID := range userIDs.(*schema.Set).List() {
+		payload[i] = int32(userID.(int))
+	}
 
-  svc := client.Services.RolesV1
+	svc := client.Services.RolesV1
 	_, err := svc.Repository.Destroy(olhttp.OLHTTPRequest{
 		URL:        fmt.Sprintf("%s/%d/users", svc.Endpoint, int32(roleID.(int))),
 		Headers:    map[string]string{"Content-Type": "application/json"},


### PR DESCRIPTION
## Background

This PR resolve issue #80
https://github.com/onelogin/onelogin-go-sdk/pull/62 is required

## How it work

```
resource "onelogin_roles" "role" {
  name   = "Test Role"
  apps   = [
    local.app_id,
  ]
  users  = []
  admins = []

  lifecycle {
    ignore_changes = [users, admins]
  }
}

resource "onelogin_user_role_attachments" "attachments" {
  role_id = onelogin_roles.role.id
  users = [
     local.user_a.id,
     local.user_b.id,
  ]
}
```