### PR TITLE
Update GitHub Actions and Security scanning tool

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,7 @@
-on: [push, pull_request]
 name: CI
+
+on: [push, pull_request]
+
 jobs:
   tests:
     runs-on: ubuntu-latest
@@ -7,16 +9,24 @@ jobs:
       GO111MODULE: on
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.21'  # You can adjust this to your project's Go version
+
     - name: Format
       run: go fmt ./...
+
     - name: Build
       run: go build ./...
+
     - name: Vet
       run: go vet ./...
+
     - name: Test
-      uses: cedrickring/golang-action@master
-      with:
-        args: make test
+      run: make test
+
     - name: Secure
       run: make secure

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,5 +28,9 @@ jobs:
     - name: Test
       run: make test
 
+    - name: Install gosec
+      run: |
+        curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
+
     - name: Secure
       run: make secure

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Install gosec
       run: |
-        curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
+        curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.18.2
 
     - name: Secure
       run: make secure

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -61,5 +61,4 @@ secure:
 	# excludes G304 (potential file inclusion) - The file needs to be read in order to run acceptance tests by hashicorp
 	# excludes G401 (Use of weak cryptographic primitive) - md5 is perfectly enough to create a unique data source ID
 	# excludes G501 (Blocklisted import crypto/md5: weak cryptographic primitive) - md5 is perfectly enough to create a unique data source ID
-	curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s
-	./bin/gosec -exclude=G104,G304,G109,G401,G501 ./...
+	gosec -exclude=G104,G304,G109,G401,G501 ./...

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
     2) Install Terraform v0.12.24 or later
     3) Install gosec (for security scanning):
        ```
-       curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
+       curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.18.2
        ```
     4) Install code dependencies
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,11 @@
 # Prerequisites
     1) Install Golang
     2) Install Terraform v0.12.24 or later
-    3) Install code dependencies
+    3) Install gosec (for security scanning):
+       ```
+       curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
+       ```
+    4) Install code dependencies
 
 # Getting Started W/ Local Testing & Development
 If you are sideloading this provider (i.e. not getting this via the Terraform store) You must clone this repository to run the following commands.
@@ -143,4 +147,3 @@ make test
 **secure** runs gosec code analysis to warn about possible exploits specific to go
 ```
 make secure
-````


### PR DESCRIPTION
This pull request includes updates to the CI workflow, security scanning setup, and documentation for a Go project. The most important changes are the upgrade of GitHub Actions and the addition of a security scanning tool.

CI Workflow Improvements:

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL1-R34): Upgraded `actions/checkout` to v3 and added `actions/setup-go` to set up Go 1.21. Changed the `Test` step to run `make test` directly and added a step to install `gosec` for security scanning.

Security Scanning:

* [`GNUmakefile`](diffhunk://#diff-e3445fc75aa9c3e4a60fbe5394dcce12693022018216a8fbe0000fe9952850a6L64-R64): Modified the `secure` target to use the `gosec` binary directly instead of downloading and running the installation script each time.

Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L8-R12): Added instructions to install `gosec` for security scanning and updated the prerequisites section accordingly.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L146): Removed an extra backtick from the `make test` section.