### PR TITLE
fix: add configurable timeout setting for OneLogin provider

### DIFF
--- a/onelogin/provider.go
+++ b/onelogin/provider.go
@@ -39,6 +39,12 @@ func Provider() *schema.Provider {
 				Optional: true,
 				Default:  client.USRegion,
 			},
+			"timeout": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("ONELOGIN_CLIENT_TIMEOUT", 60),
+				Description: "Timeout in seconds for API operations. Defaults to 60 seconds if not specified.",
+			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"onelogin_user":  dataSourceUser(),
@@ -70,10 +76,11 @@ func configProvider(ctx context.Context, d *schema.ResourceData) (interface{}, d
 	region := d.Get("region").(string)
 	url := d.Get("url").(string)
 
-	timeout := client.DefaultTimeout
+	// Get timeout from configuration
+	timeoutSeconds := d.Get("timeout").(int)
 
 	oneloginClient, err := client.NewClient(&client.APIClientConfig{
-		Timeout:      timeout,
+		Timeout:      timeoutSeconds,
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
 		Region:       region,


### PR DESCRIPTION
This pull request introduces a new configuration option for setting a timeout in the OneLogin provider. The addition allows users to specify the timeout for API operations, improving flexibility and control over API interactions.

### Enhancements to OneLogin provider configuration:

* [`onelogin/provider.go`](diffhunk://#diff-67f9eb98d74e43b0177e4868b4575c740c8fed94dc98974964d3601c3c609b94R42-R47): Added a new `timeout` configuration option to the provider schema. This option allows users to set a timeout in seconds for API operations, with a default value of 60 seconds. The value can also be sourced from the `ONELOGIN_CLIENT_TIMEOUT` environment variable.
* [`onelogin/provider.go`](diffhunk://#diff-67f9eb98d74e43b0177e4868b4575c740c8fed94dc98974964d3601c3c609b94L73-R83): Updated the `configProvider` function to retrieve the `timeout` value from the configuration and pass it to the `client.APIClientConfig`. This replaces the previous hardcoded default timeout.