### PR TITLE
docs: update getting-started instructions for v0.7.0

### DIFF
--- a/getting-started/README.md
+++ b/getting-started/README.md
@@ -46,31 +46,31 @@ If you encounter issues with the provider availability in the Terraform Registry
 1. Create the plugins directory (adjust OS and architecture as needed):
    ```bash
    # For macOS Intel
-   mkdir -p ~/.terraform.d/plugins/registry.terraform.io/onelogin/onelogin/0.6.0/darwin_amd64
+   mkdir -p ~/.terraform.d/plugins/registry.terraform.io/onelogin/onelogin/0.7.0/darwin_amd64
 
    # For macOS Apple Silicon (M1/M2)
-   mkdir -p ~/.terraform.d/plugins/registry.terraform.io/onelogin/onelogin/0.6.0/darwin_arm64
+   mkdir -p ~/.terraform.d/plugins/registry.terraform.io/onelogin/onelogin/0.7.0/darwin_arm64
 
    # For Linux
-   mkdir -p ~/.terraform.d/plugins/registry.terraform.io/onelogin/onelogin/0.6.0/linux_amd64
+   mkdir -p ~/.terraform.d/plugins/registry.terraform.io/onelogin/onelogin/0.7.0/linux_amd64
 
    # For Windows
-   mkdir -p %APPDATA%\terraform.d\plugins\registry.terraform.io\onelogin\onelogin\0.6.0\windows_amd64
+   mkdir -p %APPDATA%\terraform.d\plugins\registry.terraform.io\onelogin\onelogin\0.7.0\windows_amd64
    ```
 
 2. Download the provider binary from GitHub releases:
    ```bash
    # For macOS Intel
-   curl -L https://github.com/onelogin/terraform-provider-onelogin/releases/download/v0.6.0/terraform-provider-onelogin_0.6.0_darwin_amd64.zip -o /tmp/provider.zip
+   curl -L https://github.com/onelogin/terraform-provider-onelogin/releases/download/v0.7.0/terraform-provider-onelogin_0.7.0_darwin_amd64.zip -o /tmp/provider.zip
 
    # For macOS Apple Silicon
-   curl -L https://github.com/onelogin/terraform-provider-onelogin/releases/download/v0.6.0/terraform-provider-onelogin_0.6.0_darwin_arm64.zip -o /tmp/provider.zip
+   curl -L https://github.com/onelogin/terraform-provider-onelogin/releases/download/v0.7.0/terraform-provider-onelogin_0.7.0_darwin_arm64.zip -o /tmp/provider.zip
 
    # For Linux
-   curl -L https://github.com/onelogin/terraform-provider-onelogin/releases/download/v0.6.0/terraform-provider-onelogin_0.6.0_linux_amd64.zip -o /tmp/provider.zip
+   curl -L https://github.com/onelogin/terraform-provider-onelogin/releases/download/v0.7.0/terraform-provider-onelogin_0.7.0_linux_amd64.zip -o /tmp/provider.zip
 
    # For Windows (using PowerShell)
-   Invoke-WebRequest -Uri https://github.com/onelogin/terraform-provider-onelogin/releases/download/v0.6.0/terraform-provider-onelogin_0.6.0_windows_amd64.zip -OutFile $env:TEMP\provider.zip
+   Invoke-WebRequest -Uri https://github.com/onelogin/terraform-provider-onelogin/releases/download/v0.7.0/terraform-provider-onelogin_0.7.0_windows_amd64.zip -OutFile $env:TEMP\provider.zip
    ```
 
 3. Extract and install:
@@ -81,22 +81,22 @@ If you encounter issues with the provider availability in the Terraform Registry
    # Check the actual contents and structure of the extracted files
    ls -la /tmp/provider
 
-   # For macOS Intel (adjust filenames based on what you see in the previous step)
-   cp /tmp/provider/terraform-provider-onelogin_v0.6.0 ~/.terraform.d/plugins/registry.terraform.io/onelogin/onelogin/0.6.0/darwin_amd64/
-   chmod +x ~/.terraform.d/plugins/registry.terraform.io/onelogin/onelogin/0.6.0/darwin_amd64/terraform-provider-onelogin_v0.6.0
+   # For macOS Intel (adjust the destination directory path if needed)
+   cp /tmp/provider/terraform-provider-onelogin ~/.terraform.d/plugins/registry.terraform.io/onelogin/onelogin/0.7.0/darwin_amd64/
+   chmod +x ~/.terraform.d/plugins/registry.terraform.io/onelogin/onelogin/0.7.0/darwin_amd64/terraform-provider-onelogin
 
-   # For macOS Apple Silicon (adjust filenames based on what you see)
-   cp /tmp/provider/terraform-provider-onelogin_v0.6.0 ~/.terraform.d/plugins/registry.terraform.io/onelogin/onelogin/0.6.0/darwin_arm64/
-   chmod +x ~/.terraform.d/plugins/registry.terraform.io/onelogin/onelogin/0.6.0/darwin_arm64/terraform-provider-onelogin_v0.6.0
+   # For macOS Apple Silicon (adjust the destination directory path if needed)
+   cp /tmp/provider/terraform-provider-onelogin ~/.terraform.d/plugins/registry.terraform.io/onelogin/onelogin/0.7.0/darwin_arm64/
+   chmod +x ~/.terraform.d/plugins/registry.terraform.io/onelogin/onelogin/0.7.0/darwin_arm64/terraform-provider-onelogin
 
-   # For Linux (adjust filenames based on what you see)
-   cp /tmp/provider/terraform-provider-onelogin_v0.6.0 ~/.terraform.d/plugins/registry.terraform.io/onelogin/onelogin/0.6.0/linux_amd64/
-   chmod +x ~/.terraform.d/plugins/registry.terraform.io/onelogin/onelogin/0.6.0/linux_amd64/terraform-provider-onelogin_v0.6.0
+   # For Linux (adjust the destination directory path if needed)
+   cp /tmp/provider/terraform-provider-onelogin ~/.terraform.d/plugins/registry.terraform.io/onelogin/onelogin/0.7.0/linux_amd64/
+   chmod +x ~/.terraform.d/plugins/registry.terraform.io/onelogin/onelogin/0.7.0/linux_amd64/terraform-provider-onelogin
 
-   # For Windows (using PowerShell) (adjust filenames based on what you see)
+   # For Windows (using PowerShell) (adjust the destination directory path if needed)
    Expand-Archive -Path $env:TEMP\provider.zip -DestinationPath $env:TEMP\provider
    Get-ChildItem -Path $env:TEMP\provider -Recurse
-   Copy-Item $env:TEMP\provider\terraform-provider-onelogin_v0.6.0.exe $env:APPDATA\terraform.d\plugins\registry.terraform.io\onelogin\onelogin\0.6.0\windows_amd64\
+   Copy-Item $env:TEMP\provider\terraform-provider-onelogin.exe $env:APPDATA\terraform.d\plugins\registry.terraform.io\onelogin\onelogin\0.7.0\windows_amd64\
    ```
 
    > **Note:** The exact structure and filenames inside the zip may vary between releases. After extraction, check the actual contents with `ls` or `Get-ChildItem` and adjust the copy commands accordingly. The binary may be in a subdirectory or have a slightly different name.


### PR DESCRIPTION
This pull request updates the `getting-started/README.md` file to reflect the latest version (v0.7.0) of the `terraform-provider-onelogin`. The changes ensure that the instructions for setting up the provider are consistent with the new version.

### Updates for Terraform Provider Version

* Updated all directory paths to reference `0.7.0` instead of `0.6.0` for the provider installation instructions across macOS (Intel and Apple Silicon), Linux, and Windows. (`[getting-started/README.mdL49-R73](diffhunk://#diff-ce2a8ca7a1f56da427e3b975745401cf814bdec361bd98d5b149338042b1bc94L49-R73)`)
* Updated the download URLs to point to the v0.7.0 release of the provider binary for all supported platforms. (`[getting-started/README.mdL49-R73](diffhunk://#diff-ce2a8ca7a1f56da427e3b975745401cf814bdec361bd98d5b149338042b1bc94L49-R73)`)
* Adjusted file copy commands to remove version-specific filenames and ensure compatibility with the new binary naming convention. (`[getting-started/README.mdL84-R99](diffhunk://#diff-ce2a8ca7a1f56da427e3b975745401cf814bdec361bd98d5b149338042b1bc94L84-R99)`)