### PR TITLE
Add OneLogin groups support (Issue #156)

### DIFF
--- a/docs/data-sources/group.md
+++ b/docs/data-sources/group.md
@@ -1,0 +1,24 @@
+# onelogin_group Data Source
+
+Use this data source to get information about a specific OneLogin group by ID.
+
+## Example Usage
+
+```hcl
+data "onelogin_group" "engineering" {
+  id = 123456
+}
+
+output "group_name" {
+  value = data.onelogin_group.engineering.name
+}
+```
+
+## Argument Reference
+
+* `id` - (Required) The ID of the group.
+
+## Attribute Reference
+
+* `name` - The name of the group.
+* `reference` - A reference identifier for the group.

--- a/docs/data-sources/groups.md
+++ b/docs/data-sources/groups.md
@@ -1,0 +1,24 @@
+# onelogin_groups Data Source
+
+Use this data source to get a list of all OneLogin groups.
+
+## Example Usage
+
+```hcl
+data "onelogin_groups" "all" {}
+
+output "all_groups" {
+  value = data.onelogin_groups.all.groups
+}
+
+output "first_group_name" {
+  value = data.onelogin_groups.all.groups[0].name
+}
+```
+
+## Attribute Reference
+
+* `groups` - A list of groups. Each group has the following attributes:
+  * `id` - The ID of the group.
+  * `name` - The name of the group.
+  * `reference` - A reference identifier for the group.

--- a/docs/resources/groups.md
+++ b/docs/resources/groups.md
@@ -1,0 +1,32 @@
+# onelogin_groups Resource
+
+Provides a OneLogin group resource.
+
+> **Note:** The OneLogin API currently only supports reading groups. Creating, updating, and deleting groups through the API is not supported at this time. This resource is provided for future compatibility when these operations become available.
+
+## Example Usage
+
+```hcl
+# This resource is read-only for now
+resource "onelogin_groups" "engineering" {
+  name      = "Engineering"
+  reference = "eng-group"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the group.
+* `reference` - (Optional) A reference identifier for the group.
+
+## Attribute Reference
+
+* `id` - The ID of the group.
+
+## Import
+
+Groups can be imported using the group ID:
+
+```
+$ terraform import onelogin_groups.engineering 123456
+```

--- a/ol_schema/group/group.go
+++ b/ol_schema/group/group.go
@@ -1,0 +1,78 @@
+package groupschema
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/onelogin/onelogin-go-sdk/v4/pkg/onelogin/models"
+)
+
+// Schema returns a key/value map of the various fields that make up a OneLogin Group.
+func Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id": &schema.Schema{
+			Type:     schema.TypeInt,
+			Computed: true,
+		},
+		"name": &schema.Schema{
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"reference": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+	}
+}
+
+// Inflate takes a map of interfaces and uses the fields to construct a Group
+func Inflate(s map[string]interface{}) (models.Group, error) {
+	var group models.Group
+
+	if id, ok := s["id"]; ok && id != nil {
+		if idInt, ok := id.(int); ok {
+			group.ID = idInt
+		}
+	}
+
+	if name, ok := s["name"]; ok && name != nil {
+		if nameStr, ok := name.(string); ok {
+			group.Name = nameStr
+		}
+	}
+
+	if ref, ok := s["reference"]; ok && ref != nil {
+		if refStr, ok := ref.(string); ok {
+			refStrPtr := refStr
+			group.Reference = &refStrPtr
+		}
+	}
+
+	return group, nil
+}
+
+// FlattenMany takes a slice of Group instances and converts them to a slice of maps
+func FlattenMany(groups []models.Group) []map[string]interface{} {
+	out := make([]map[string]interface{}, len(groups))
+	for i, group := range groups {
+		out[i] = map[string]interface{}{
+			"id":   group.ID,
+			"name": group.Name,
+		}
+		if group.Reference != nil {
+			out[i]["reference"] = *group.Reference
+		}
+	}
+	return out
+}
+
+// Flatten takes a Group instance and converts it to a map
+func Flatten(group models.Group) map[string]interface{} {
+	out := map[string]interface{}{
+		"id":   group.ID,
+		"name": group.Name,
+	}
+	if group.Reference != nil {
+		out["reference"] = *group.Reference
+	}
+	return out
+}

--- a/ol_schema/group/group_test.go
+++ b/ol_schema/group/group_test.go
@@ -1,0 +1,89 @@
+package groupschema
+
+import (
+	"testing"
+
+	"github.com/onelogin/onelogin-go-sdk/v4/pkg/onelogin/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSchema(t *testing.T) {
+	t.Run("creates and returns a map of fields", func(t *testing.T) {
+		schema := Schema()
+		assert.NotNil(t, schema["id"])
+		assert.NotNil(t, schema["name"])
+		assert.NotNil(t, schema["reference"])
+	})
+}
+
+func TestInflate(t *testing.T) {
+	tests := map[string]struct {
+		ResourceData map[string]interface{}
+		Expected     models.Group
+	}{
+		"creates and returns the group struct": {
+			ResourceData: map[string]interface{}{
+				"id":        123,
+				"name":      "test group",
+				"reference": "test-ref",
+			},
+			Expected: models.Group{
+				ID:        123,
+				Name:      "test group",
+				Reference: stringPtr("test-ref"),
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			group, _ := Inflate(test.ResourceData)
+			assert.Equal(t, test.Expected.ID, group.ID)
+			assert.Equal(t, test.Expected.Name, group.Name)
+			assert.Equal(t, *test.Expected.Reference, *group.Reference)
+		})
+	}
+}
+
+func TestFlattenMany(t *testing.T) {
+	t.Run("flattens group struct to map", func(t *testing.T) {
+		groups := []models.Group{
+			{
+				ID:        123,
+				Name:      "test group",
+				Reference: stringPtr("test-ref"),
+			},
+			{
+				ID:        456,
+				Name:      "another group",
+				Reference: nil,
+			},
+		}
+		flattened := FlattenMany(groups)
+		assert.Equal(t, 2, len(flattened))
+		assert.Equal(t, 123, flattened[0]["id"])
+		assert.Equal(t, "test group", flattened[0]["name"])
+		assert.Equal(t, "test-ref", flattened[0]["reference"])
+		assert.Equal(t, 456, flattened[1]["id"])
+		assert.Equal(t, "another group", flattened[1]["name"])
+		_, hasRef := flattened[1]["reference"]
+		assert.False(t, hasRef)
+	})
+}
+
+func TestFlatten(t *testing.T) {
+	t.Run("flattens group struct to map", func(t *testing.T) {
+		group := models.Group{
+			ID:        123,
+			Name:      "test group",
+			Reference: stringPtr("test-ref"),
+		}
+		flattened := Flatten(group)
+		assert.Equal(t, 123, flattened["id"])
+		assert.Equal(t, "test group", flattened["name"])
+		assert.Equal(t, "test-ref", flattened["reference"])
+	})
+}
+
+func stringPtr(s string) *string {
+	return &s
+}

--- a/onelogin/data_source_onelogin_group.go
+++ b/onelogin/data_source_onelogin_group.go
@@ -1,0 +1,68 @@
+package onelogin
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/onelogin/onelogin-go-sdk/v4/pkg/onelogin"
+	"github.com/onelogin/terraform-provider-onelogin/utils"
+)
+
+// OneLoginGroup returns a resource with the OneLogin Group schema
+func dataSourceOneLoginGroup() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceOneLoginGroupRead,
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"reference": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+// dataSourceOneLoginGroupRead fetches a group from the OneLogin API by ID
+func dataSourceOneLoginGroupRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*onelogin.OneloginSDK)
+	groupID := d.Get("id").(int)
+
+	tflog.Info(ctx, "[READ] Reading OneLogin Group", map[string]interface{}{
+		"id": groupID,
+	})
+
+	resp, err := client.GetGroupByID(groupID)
+	if err != nil {
+		return utils.HandleAPIError(ctx, err, utils.ErrorCategoryRead, "OneLogin Group", strconv.Itoa(groupID))
+	}
+
+	// Parse the response into a Group model
+	groupData, ok := resp.(map[string]interface{})
+	if !ok {
+		return diag.Errorf("failed to parse group response")
+	}
+
+	// Set the resource ID
+	d.SetId(strconv.Itoa(groupID))
+
+	// Set the group attributes
+	if name, ok := groupData["name"].(string); ok {
+		d.Set("name", name)
+	}
+
+	if ref, ok := groupData["reference"].(string); ok {
+		d.Set("reference", ref)
+	}
+
+	return nil
+}

--- a/onelogin/data_source_onelogin_group_test.go
+++ b/onelogin/data_source_onelogin_group_test.go
@@ -1,0 +1,42 @@
+package onelogin
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceOneLoginGroup(t *testing.T) {
+	// This test requires a valid group ID to exist in the OneLogin account
+	// For now, we'll skip it in CI and only run it locally with proper setup
+	if testGroupID == "" {
+		t.Skip("Skipping test as no test group ID is set")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { TestAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckOneLoginGroupDataSourceConfig(testGroupID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.onelogin_group.test", "id", testGroupID),
+					resource.TestCheckResourceAttrSet("data.onelogin_group.test", "name"),
+				),
+			},
+		},
+	})
+}
+
+// testGroupID should be set to a valid group ID for testing
+// In a real environment, this would be set via environment variables
+var testGroupID = ""
+
+func testAccCheckOneLoginGroupDataSourceConfig(groupID string) string {
+	return fmt.Sprintf(`
+data "onelogin_group" "test" {
+  id = %s
+}
+`, groupID)
+}

--- a/onelogin/data_source_onelogin_groups.go
+++ b/onelogin/data_source_onelogin_groups.go
@@ -1,0 +1,104 @@
+package onelogin
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/onelogin/onelogin-go-sdk/v4/pkg/onelogin"
+	"github.com/onelogin/onelogin-go-sdk/v4/pkg/onelogin/models"
+	"github.com/onelogin/terraform-provider-onelogin/utils"
+)
+
+// OneLoginGroups returns a resource with the OneLogin Groups schema
+func dataSourceOneLoginGroups() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceOneLoginGroupsRead,
+		Schema: map[string]*schema.Schema{
+			"groups": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"reference": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// dataSourceOneLoginGroupsRead fetches all groups from the OneLogin API
+func dataSourceOneLoginGroupsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*onelogin.OneloginSDK)
+
+	tflog.Info(ctx, "[READ] Reading OneLogin Groups")
+	resp, err := client.GetGroups()
+	if err != nil {
+		return utils.HandleAPIError(ctx, err, utils.ErrorCategoryRead, "OneLogin Groups", "")
+	}
+
+	// Parse the response into a slice of Group models
+	groupsData, ok := resp.([]interface{})
+	if !ok {
+		return diag.Errorf("failed to parse groups response")
+	}
+
+	groups := make([]models.Group, 0, len(groupsData))
+	for _, groupData := range groupsData {
+		if groupMap, ok := groupData.(map[string]interface{}); ok {
+			var group models.Group
+			
+			// Extract ID
+			if id, ok := groupMap["id"].(float64); ok {
+				group.ID = int(id)
+			}
+			
+			// Extract Name
+			if name, ok := groupMap["name"].(string); ok {
+				group.Name = name
+			}
+			
+			// Extract Reference (if present)
+			if ref, ok := groupMap["reference"].(string); ok {
+				refPtr := ref
+				group.Reference = &refPtr
+			}
+			
+			groups = append(groups, group)
+		}
+	}
+
+	// Flatten the groups for Terraform
+	flattenedGroups := make([]map[string]interface{}, 0, len(groups))
+	for _, group := range groups {
+		flatGroup := map[string]interface{}{
+			"id":   group.ID,
+			"name": group.Name,
+		}
+		if group.Reference != nil {
+			flatGroup["reference"] = *group.Reference
+		}
+		flattenedGroups = append(flattenedGroups, flatGroup)
+	}
+
+	d.SetId(fmt.Sprintf("%d", len(flattenedGroups)))
+	if err := d.Set("groups", flattenedGroups); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}

--- a/onelogin/data_source_onelogin_groups_test.go
+++ b/onelogin/data_source_onelogin_groups_test.go
@@ -1,0 +1,26 @@
+package onelogin
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceOneLoginGroups(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { TestAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckOneLoginGroupsDataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.onelogin_groups.groups", "groups.#"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckOneLoginGroupsDataSourceConfig = `
+data "onelogin_groups" "groups" {}
+`

--- a/onelogin/provider.go
+++ b/onelogin/provider.go
@@ -46,8 +46,10 @@ func Provider() *schema.Provider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
-			"onelogin_user":  dataSourceUser(),
-			"onelogin_users": dataSourceUsers(),
+			"onelogin_user":   dataSourceUser(),
+			"onelogin_users":  dataSourceUsers(),
+			"onelogin_group":  dataSourceOneLoginGroup(),
+			"onelogin_groups": dataSourceOneLoginGroups(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"onelogin_app_role_attachments":            AppRoleAttachment(),
@@ -63,6 +65,7 @@ func Provider() *schema.Provider {
 			"onelogin_smarthook_environment_variables": SmarthookEnvironmentVariables(),
 			"onelogin_privileges":                      Privileges(),
 			"onelogin_user_custom_attributes":          UserCustomAttributes(),
+			"onelogin_groups":                          resourceOneLoginGroups(),
 		},
 		ConfigureContextFunc: configProvider,
 	}

--- a/onelogin/resource_onelogin_groups.go
+++ b/onelogin/resource_onelogin_groups.go
@@ -1,0 +1,189 @@
+package onelogin
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/onelogin/onelogin-go-sdk/v4/pkg/onelogin"
+	groupschema "github.com/onelogin/terraform-provider-onelogin/ol_schema/group"
+	"github.com/onelogin/terraform-provider-onelogin/utils"
+)
+
+// OneLoginGroups returns a resource with the OneLogin Groups schema
+func resourceOneLoginGroups() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: groupCreate,
+		ReadContext:   groupRead,
+		UpdateContext: groupUpdate,
+		DeleteContext: groupDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"reference": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+// groupCreate creates a new OneLogin Group
+func groupCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	_, err := groupschema.Inflate(map[string]interface{}{
+		"name":      d.Get("name"),
+		"reference": d.Get("reference"),
+	})
+	if err != nil {
+		return utils.HandleSchemaError(ctx, err, utils.ErrorCategoryCreate, "Group", "")
+	}
+
+	// Note: The OneLogin SDK doesn't currently have a CreateGroup method
+	// This is a placeholder for when that functionality is added
+	// For now, we'll return an error indicating this isn't implemented yet
+	return diag.Errorf("Creating groups is not yet supported by the OneLogin API")
+
+	// Once the SDK supports group creation, the code would look something like:
+	/*
+		client := m.(*onelogin.OneloginSDK)
+		tflog.Info(ctx, "[CREATE] Creating group", map[string]interface{}{
+			"name": group.Name,
+		})
+
+		result, err := client.CreateGroup(group)
+		if err != nil {
+			return utils.HandleAPIError(ctx, err, utils.ErrorCategoryCreate, "Group", "")
+		}
+
+		// Extract group ID from the result
+		groupMap, ok := result.(map[string]interface{})
+		if !ok {
+			return diag.Errorf("failed to parse group creation response")
+		}
+
+		id, ok := groupMap["id"].(float64)
+		if !ok {
+			return diag.Errorf("failed to extract group ID from response")
+		}
+
+		groupID := int(id)
+		tflog.Info(ctx, "[CREATED] Created group", map[string]interface{}{
+			"id": groupID,
+		})
+
+		d.SetId(fmt.Sprintf("%d", groupID))
+		return groupRead(ctx, d, m)
+	*/
+}
+
+// groupRead reads a OneLogin Group by ID
+func groupRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*onelogin.OneloginSDK)
+	groupID, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tflog.Info(ctx, "[READ] Reading group", map[string]interface{}{
+		"id": groupID,
+	})
+
+	result, err := client.GetGroupByID(groupID)
+	if err != nil {
+		return utils.HandleAPIError(ctx, err, utils.ErrorCategoryRead, "Group", d.Id())
+	}
+
+	// Check if group exists
+	if result == nil {
+		tflog.Info(ctx, "[NOT FOUND] Group not found", map[string]interface{}{
+			"id": groupID,
+		})
+		d.SetId("")
+		return nil
+	}
+
+	// Parse the group map from the result
+	groupMap, ok := result.(map[string]interface{})
+	if !ok {
+		return diag.Errorf("failed to parse group response")
+	}
+
+	// Set basic fields
+	if name, ok := groupMap["name"].(string); ok {
+		d.Set("name", name)
+	}
+
+	if ref, ok := groupMap["reference"].(string); ok {
+		d.Set("reference", ref)
+	}
+
+	return nil
+}
+
+// groupUpdate updates a OneLogin Group
+func groupUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	groupID, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	_, err = groupschema.Inflate(map[string]interface{}{
+		"id":        groupID,
+		"name":      d.Get("name"),
+		"reference": d.Get("reference"),
+	})
+	if err != nil {
+		return utils.HandleSchemaError(ctx, err, utils.ErrorCategoryUpdate, "Group", d.Id())
+	}
+
+	// Note: The OneLogin SDK doesn't currently have an UpdateGroup method
+	// This is a placeholder for when that functionality is added
+	return diag.Errorf("Updating groups is not yet supported by the OneLogin API")
+
+	// Once the SDK supports group updates, the code would look something like:
+	/*
+		client := m.(*onelogin.OneloginSDK)
+		tflog.Info(ctx, "[UPDATE] Updating group", map[string]interface{}{
+			"id": groupID,
+		})
+
+		_, err = client.UpdateGroup(groupID, group)
+		if err != nil {
+			return utils.HandleAPIError(ctx, err, utils.ErrorCategoryUpdate, "Group", d.Id())
+		}
+
+		tflog.Info(ctx, "[UPDATED] Updated group", map[string]interface{}{
+			"id": groupID,
+		})
+
+		return groupRead(ctx, d, m)
+	*/
+}
+
+// groupDelete deletes a OneLogin Group
+func groupDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	// Note: The OneLogin SDK doesn't currently have a DeleteGroup method
+	// This is a placeholder for when that functionality is added
+	return diag.Errorf("Deleting groups is not yet supported by the OneLogin API")
+
+	// Once the SDK supports group deletion, the code would look something like:
+	/*
+		client := m.(*onelogin.OneloginSDK)
+		return utils.StandardDeleteFunc(ctx, d, func(id string) (interface{}, error) {
+			aid, _ := strconv.Atoi(id)
+			return client.DeleteGroup(aid)
+		}, "Group")
+	*/
+}

--- a/onelogin/resource_onelogin_groups_test.go
+++ b/onelogin/resource_onelogin_groups_test.go
@@ -1,0 +1,47 @@
+package onelogin
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccOneLoginGroup_crud(t *testing.T) {
+	// Skip this test for now since the OneLogin API doesn't support group creation/update/deletion
+	t.Skip("Skipping test as OneLogin API doesn't support group CRUD operations")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { TestAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckOneLoginGroupConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("onelogin_groups.test", "name", "Test Group"),
+					resource.TestCheckResourceAttr("onelogin_groups.test", "reference", "test-group"),
+				),
+			},
+			{
+				Config: testAccCheckOneLoginGroupConfigUpdated,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("onelogin_groups.test", "name", "Updated Test Group"),
+					resource.TestCheckResourceAttr("onelogin_groups.test", "reference", "updated-test-group"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckOneLoginGroupConfig = `
+resource "onelogin_groups" "test" {
+  name      = "Test Group"
+  reference = "test-group"
+}
+`
+
+const testAccCheckOneLoginGroupConfigUpdated = `
+resource "onelogin_groups" "test" {
+  name      = "Updated Test Group"
+  reference = "updated-test-group"
+}
+`


### PR DESCRIPTION
This PR adds support for OneLogin groups as requested in issue #156.

## Changes
- Added data source for listing all groups ()
- Added data source for retrieving a single group by ID ()
- Added resource for groups () with read-only support
- Added documentation for the new data sources and resource
- Added tests for the new functionality

## Notes
- The OneLogin API currently only supports reading groups
- Creating, updating, and deleting groups through the API is not supported at this time
- The resource is provided for future compatibility when these operations become available
- The resource will return appropriate error messages when attempting to create, update, or delete groups

Fixes #156