### PR TITLE
Bump version to 0.8.4

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -10,7 +10,7 @@ GO111MODULE=on
 
 PLUGINS_DIR=~/.terraform.d/plugins
 PLUGIN_PATH=onelogin.com/onelogin/onelogin
-VERSION=0.8.3
+VERSION=0.8.4
 
 clean:
 	rm -r ${DIST_DIR}

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ terraform {
   required_providers {
     onelogin = {
       source  = "onelogin/onelogin"
-      version = "0.8.3"
+      version = "0.8.4"
     }
   }
 }


### PR DESCRIPTION
This PR updates the version from 0.8.3 to 0.8.4 in preparation for a new release that will include the groups functionality added in PR #166.

Changes:
- Update version in GNUmakefile from 0.8.3 to 0.8.4
- Update version in README.md example from 0.8.3 to 0.8.4