### PR TITLE
update release process documentation to reflect automated GitHub Actions workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,35 +74,26 @@ make secure
 ```
 
 ## Release Process
-1. Create feature branch from `main`
-2. Create PR against `main`
-3. After approval and CI passing, merge to `main`
-4. Create a new branch for version bump:
-   ```bash
-   git checkout main
-   git pull
-   git checkout -b bump-version-x.x.x
-   ```
-5. Update version numbers:
-   - Update `VERSION` in `GNUmakefile`
-   - Update version in the example provider configuration in `README.md`
-6. Commit version changes and create a PR:
-   ```bash
-   git commit -a -m "Bump version to x.x.x"
-   git push -u origin bump-version-x.x.x
-   # Create PR via GitHub UI
-   ```
-7. After the version bump PR is merged, create a new tag:
-   ```bash
-   git checkout main
-   git pull
-   git tag vX.X.X
-   git push origin vX.X.X
-   ```
-8. The GitHub Action will automatically:
-   - Build the provider
-   - Create a GitHub release
-   - Publish to the Terraform Registry
+1. **Run the Version Bump GitHub Action:**
+   - Go to the [Actions tab](../../actions) in GitHub
+   - Select "Version Bump" workflow
+   - Click "Run workflow"
+   - Choose the bump type (major, minor, or patch)
+   - The action will automatically:
+     - Update `VERSION` in `GNUmakefile`
+     - Update version in the example provider configuration in `README.md`
+     - Create a PR with the version changes
+
+2. **After the version bump PR is merged, create a GitHub Release:**
+   - Go to the [Releases page](../../releases) in GitHub
+   - Click "Draft a new release"
+   - Click "Choose a tag" and create a new tag (e.g., `v0.5.2`)
+   - Set the release title and description
+   - Click "Publish release"
+   - The Release workflow will automatically trigger and:
+     - Build the provider
+     - Attach binaries to the GitHub release
+     - Publish to the Terraform Registry
 
 Note: Tags should follow semantic versioning (e.g., v0.5.2)
 


### PR DESCRIPTION
This pull request updates the release process documentation in `README.md` to streamline and automate version bumping and release creation using GitHub Actions. The instructions now reflect a more modern workflow, reducing manual steps and clarifying how releases should be published.

Release process automation:

* Replaced manual version bumping steps with instructions to use the "Version Bump" GitHub Action, which updates the `GNUmakefile` and example provider configuration, then creates a PR automatically.
* Updated the release creation steps to use the GitHub Releases page, with the "Release" workflow automatically building, attaching binaries, and publishing to the Terraform Registry after a release is published.