### PR TITLE
[no-ado] Drop obsolete PASSPHRASE env from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,6 @@ jobs:
         uses: paultyng/ghaction-import-gpg@v2.1.0
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5


### PR DESCRIPTION
## Summary
- The repo's GPG signing key was rotated on 2026-05-27 to a passphrase-less key (fingerprint `2098CDF776EB66023DB924E138D4DBED37F2F2DD`, UID `Will Munslow <will.munslow@oneidentity.com>`).
- The corresponding `PASSPHRASE` GitHub Actions secret has been deleted, so the `PASSPHRASE: ${{ secrets.PASSPHRASE }}` env line in `release.yml` is a dangling reference to a non-existent secret. It resolved to an empty string at release time, which the `paultyng/ghaction-import-gpg` action treats as "no passphrase" anyway — so this is hygiene, not a functional fix.

## Context
The previous signing key expired and the recovered Terraform Registry account is being updated with the new public key in parallel with this PR. The new key has no passphrase by design: storing a passphrase as a sibling GHA secret next to the encrypted private key provides no real defense-in-depth (anyone with read access to one has read access to both).

## Test plan
- [ ] CI passes on this PR (no release run is triggered until a tag is pushed).
- [ ] After merging, cut a `v0.12.1` tag and confirm the Release workflow's "Import GPG key" step succeeds without `PASSPHRASE`.
- [ ] Confirm the published release's `SHA256SUMS.sig` is signed by fingerprint `2098CDF776EB66023DB924E138D4DBED37F2F2DD` and that the Terraform Registry verifies it.