### PR TITLE
feat: support position on user custom attribute definitions, fix required name

### DIFF
--- a/docs/resources/onelogin_user_custom_attributes.md
+++ b/docs/resources/onelogin_user_custom_attributes.md
@@ -28,10 +28,11 @@ resource onelogin_user_custom_attributes employee_id_definition {
   shortname = "employee_id"    # Technical name/identifier for the attribute
 }
 
-# Create another custom attribute definition
+# Create another custom attribute definition, ordered ahead of the others
 resource onelogin_user_custom_attributes department_definition {
   name      = "Department Code"
   shortname = "dept_code"
+  position  = 1
 }
 
 # Set a custom attribute value for a specific user
@@ -57,6 +58,7 @@ The following arguments are supported:
 
 * `name` - (Required) The human-readable display name of the custom attribute.
 * `shortname` - (Required) The short name (identifier) of the custom attribute.
+* `position` - (Optional) The ordering of the custom attribute definition. Positions start at 1. OneLogin leaves a definition without a position unless one is given, which this resource reports as `0`. Removing `position` from the configuration, or setting it to `0`, puts the definition back to having none.
 
 ### For User-Specific Custom Attribute Values
 

--- a/docs/resources/onelogin_user_custom_attributes.md
+++ b/docs/resources/onelogin_user_custom_attributes.md
@@ -56,7 +56,7 @@ The following arguments are supported:
 
 ### For Custom Attribute Definitions
 
-* `name` - (Required) The human-readable display name of the custom attribute.
+* `name` - (Required for definitions) The human-readable display name of the custom attribute. It is only meaningful on a definition; a resource that sets a value on a user does not need one, and any name given there is ignored.
 * `shortname` - (Required) The short name (identifier) of the custom attribute.
 * `position` - (Optional) The ordering of the custom attribute definition. Positions start at 1, and negative values are rejected. OneLogin leaves a definition without a position unless one is given, which this resource reports as `0`. Removing `position` from the configuration, or setting it to `0`, puts the definition back to having none.
 

--- a/docs/resources/onelogin_user_custom_attributes.md
+++ b/docs/resources/onelogin_user_custom_attributes.md
@@ -58,7 +58,7 @@ The following arguments are supported:
 
 * `name` - (Required) The human-readable display name of the custom attribute.
 * `shortname` - (Required) The short name (identifier) of the custom attribute.
-* `position` - (Optional) The ordering of the custom attribute definition. Positions start at 1. OneLogin leaves a definition without a position unless one is given, which this resource reports as `0`. Removing `position` from the configuration, or setting it to `0`, puts the definition back to having none.
+* `position` - (Optional) The ordering of the custom attribute definition. Positions start at 1, and negative values are rejected. OneLogin leaves a definition without a position unless one is given, which this resource reports as `0`. Removing `position` from the configuration, or setting it to `0`, puts the definition back to having none.
 
 ### For User-Specific Custom Attribute Values
 

--- a/examples/onelogin_user_custom_attributes_example.tf
+++ b/examples/onelogin_user_custom_attributes_example.tf
@@ -10,10 +10,12 @@ resource onelogin_user_custom_attributes employee_id_definition {
   shortname = "employee_id"    # Technical name/identifier for the attribute
 }
 
-# Create another custom attribute definition
+# Create another custom attribute definition, ordered ahead of the others.
+# Positions start at 1; leave it out to let the definition sit without one.
 resource onelogin_user_custom_attributes department_definition {
   name      = "Department Code"
   shortname = "dept_code"
+  position  = 1
 }
 
 # Set a custom attribute value for a specific user

--- a/onelogin/resource_onelogin_user_custom_attributes.go
+++ b/onelogin/resource_onelogin_user_custom_attributes.go
@@ -10,6 +10,57 @@ import (
 	"github.com/onelogin/onelogin-go-sdk/v4/pkg/onelogin/models"
 )
 
+// userCustomAttributeDefinitionCreateInput builds the "user_field" body handed to
+// the create endpoint.
+//
+// "position" is left out unless it is actually set. OneLogin defaults a new
+// definition's position to null, so omitting the key asks for exactly that.
+// GetOk reports false for an unset int as well as for a literal 0, which is the
+// behaviour wanted here: positions start at 1, so 0 only ever means "no
+// position".
+func userCustomAttributeDefinitionCreateInput(d *schema.ResourceData) map[string]interface{} {
+	input := map[string]interface{}{
+		"name":      d.Get("name").(string),
+		"shortname": d.Get("shortname").(string),
+	}
+
+	if position, ok := d.GetOk("position"); ok {
+		input["position"] = position.(int)
+	}
+
+	return input
+}
+
+// userCustomAttributeDefinitionUpdateInput builds the body handed to the update
+// endpoint. Unlike create, the API takes this body unwrapped rather than nested
+// under "user_field".
+//
+// It differs from the create input in two ways:
+//
+//   - "name" and "shortname" are always sent. Both are required by the API, so a
+//     body carrying only a changed position would be rejected for the missing
+//     fields.
+//   - "position" is always sent too, as an explicit null once it is no longer
+//     set. Dropping the key instead would leave the old position in place, so a
+//     definition could never be put back to having none.
+//
+// Sending it unconditionally is what the plan already describes: a position left
+// out of the configuration plans as 0, so an update that clears it is the change
+// the user was shown, not a surprise.
+func userCustomAttributeDefinitionUpdateInput(d *schema.ResourceData) map[string]interface{} {
+	input := map[string]interface{}{
+		"name":      d.Get("name").(string),
+		"shortname": d.Get("shortname").(string),
+		"position":  nil,
+	}
+
+	if position := d.Get("position").(int); position > 0 {
+		input["position"] = position
+	}
+
+	return input
+}
+
 // UserCustomAttributes returns a resource with the CRUD methods and Terraform Schema defined
 func UserCustomAttributes() *schema.Resource {
 	return &schema.Resource{
@@ -28,6 +79,12 @@ func UserCustomAttributes() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Short name identifier for the custom attribute",
+			},
+			"position": {
+				Type:          schema.TypeInt,
+				Optional:      true,
+				ConflictsWith: []string{"user_id", "value"},
+				Description:   "Ordering of the custom attribute definition. Positions start at 1; leaving this unset, or setting it to 0, leaves the definition without a position",
 			},
 			"user_id": {
 				Type:        schema.TypeInt,
@@ -99,19 +156,10 @@ func userCustomAttributesCreate(d *schema.ResourceData, m interface{}) error {
 		d.SetId(fmt.Sprintf("%d_%s", userIdInt, shortname))
 		return userCustomAttributesRead(d, m)
 	} else {
-		// Otherwise, we're creating a new custom attribute definition
-		name := d.Get("name").(string)
-		shortname := d.Get("shortname").(string)
-
-		// Create payload for new custom attribute - only name and shortname are allowed
-		userFieldPayload := map[string]interface{}{
-			"name":      name,
-			"shortname": shortname,
-		}
-
-		// Wrap in user_field object as required by API
+		// Otherwise, we're creating a new custom attribute definition,
+		// wrapped in a user_field object as required by API
 		payload := map[string]interface{}{
-			"user_field": userFieldPayload,
+			"user_field": userCustomAttributeDefinitionCreateInput(d),
 		}
 
 		// Create custom attribute
@@ -186,6 +234,14 @@ func userCustomAttributesRead(d *schema.ResourceData, m interface{}) error {
 			if int(id) == attrId {
 				d.Set("name", attrMap["name"])
 				d.Set("shortname", attrMap["shortname"])
+				// A definition without a position reports null, which decodes to
+				// no float64. 0 is what the schema reports for an unset int, so
+				// the two agree and an unmanaged position is not seen as drift.
+				if position, ok := attrMap["position"].(float64); ok {
+					d.Set("position", int(position))
+				} else {
+					d.Set("position", 0)
+				}
 				return nil
 			}
 		}
@@ -257,24 +313,11 @@ func userCustomAttributesUpdate(d *schema.ResourceData, m interface{}) error {
 			return fmt.Errorf("invalid attribute ID format: %v", err)
 		}
 
-		// Create update payload
-		payload := map[string]interface{}{}
-
-		if d.HasChange("name") {
-			payload["name"] = d.Get("name").(string)
-		}
-
-		if d.HasChange("shortname") {
-			payload["shortname"] = d.Get("shortname").(string)
-		}
-
-		if len(payload) > 0 {
-			// Update the custom attribute
-			_, err := client.UpdateCustomAttributes(attrId, payload)
-			if err != nil {
-				log.Printf("[ERROR] Error updating custom attribute %d: %v", attrId, err)
-				return err
-			}
+		// Update the custom attribute
+		_, err = client.UpdateCustomAttributes(attrId, userCustomAttributeDefinitionUpdateInput(d))
+		if err != nil {
+			log.Printf("[ERROR] Error updating custom attribute %d: %v", attrId, err)
+			return err
 		}
 
 		return userCustomAttributesRead(d, m)

--- a/onelogin/resource_onelogin_user_custom_attributes.go
+++ b/onelogin/resource_onelogin_user_custom_attributes.go
@@ -10,6 +10,19 @@ import (
 	"github.com/onelogin/onelogin-go-sdk/v4/pkg/onelogin/models"
 )
 
+// validCustomAttributePosition rejects a negative position at plan time.
+//
+// Positions start at 1 and 0 stands in for "no position", so the two payload
+// builders read a negative differently: GetOk counts -1 as set and would send it
+// on create, while the update builder only treats a value above 0 as a position
+// and would clear it instead. Neither is what the configuration asked for.
+func validCustomAttributePosition(val interface{}, key string) (warns []string, errs []error) {
+	if position, ok := val.(int); ok && position < 0 {
+		errs = append(errs, fmt.Errorf("%s must be 0 or greater, got %d", key, position))
+	}
+	return warns, errs
+}
+
 // userCustomAttributeDefinitionCreateInput builds the "user_field" body handed to
 // the create endpoint.
 //
@@ -84,6 +97,7 @@ func UserCustomAttributes() *schema.Resource {
 				Type:          schema.TypeInt,
 				Optional:      true,
 				ConflictsWith: []string{"user_id", "value"},
+				ValidateFunc:  validCustomAttributePosition,
 				Description:   "Ordering of the custom attribute definition. Positions start at 1; leaving this unset, or setting it to 0, leaves the definition without a position",
 			},
 			"user_id": {

--- a/onelogin/resource_onelogin_user_custom_attributes.go
+++ b/onelogin/resource_onelogin_user_custom_attributes.go
@@ -23,6 +23,23 @@ func validCustomAttributePosition(val interface{}, key string) (warns []string, 
 	return warns, errs
 }
 
+// checkCustomAttributeDefinitionName rejects a definition that has no name. The
+// API requires one on both create and update, and the schema cannot ask for it:
+// a name is only needed for a definition, not for a value set on one user, and
+// Required applies to both shapes alike.
+//
+// This is checked at apply rather than in a CustomizeDiff because the two shapes
+// are told apart by user_id, which is commonly a reference to a user created in
+// the same run. That value is still unknown while planning, so a plan-time check
+// would read a user-value resource as a definition and demand a name it does not
+// need.
+func checkCustomAttributeDefinitionName(d *schema.ResourceData) error {
+	if d.Get("name").(string) == "" {
+		return fmt.Errorf("name is required for a custom attribute definition (shortname %q)", d.Get("shortname").(string))
+	}
+	return nil
+}
+
 // userCustomAttributeDefinitionCreateInput builds the "user_field" body handed to
 // the create endpoint.
 //
@@ -84,9 +101,15 @@ func UserCustomAttributes() *schema.Resource {
 		Importer: &schema.ResourceImporter{},
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Name of the custom attribute",
+				Type:     schema.TypeString,
+				Optional: true,
+				// Optional rather than Required because this resource has two
+				// shapes: a definition, which needs a name, and a value set on
+				// one user, which does not. Requiring it forced a throwaway name
+				// onto every user-value resource, which the documented usage and
+				// the acceptance tests never supplied. Definitions are checked
+				// for it below, at apply.
+				Description: "Name of the custom attribute. Required when managing a definition, ignored when setting a value on a user",
 			},
 			"shortname": {
 				Type:        schema.TypeString,
@@ -172,6 +195,10 @@ func userCustomAttributesCreate(d *schema.ResourceData, m interface{}) error {
 	} else {
 		// Otherwise, we're creating a new custom attribute definition,
 		// wrapped in a user_field object as required by API
+		if err := checkCustomAttributeDefinitionName(d); err != nil {
+			return err
+		}
+
 		payload := map[string]interface{}{
 			"user_field": userCustomAttributeDefinitionCreateInput(d),
 		}
@@ -325,6 +352,10 @@ func userCustomAttributesUpdate(d *schema.ResourceData, m interface{}) error {
 		attrId, err := strconv.Atoi(attrIdStr)
 		if err != nil {
 			return fmt.Errorf("invalid attribute ID format: %v", err)
+		}
+
+		if err := checkCustomAttributeDefinitionName(d); err != nil {
+			return err
 		}
 
 		// Update the custom attribute

--- a/onelogin/resource_onelogin_user_custom_attributes_test.go
+++ b/onelogin/resource_onelogin_user_custom_attributes_test.go
@@ -4,7 +4,105 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+// TestUserCustomAttributeDefinitionCreateInput covers the "user_field" body sent
+// when a definition is created. OneLogin defaults position to null, so an unset
+// position has to stay out of the body rather than go in as a zero.
+func TestUserCustomAttributeDefinitionCreateInput(t *testing.T) {
+	definition := func(extra map[string]interface{}) map[string]interface{} {
+		state := map[string]interface{}{
+			"name":      "Employee ID",
+			"shortname": "employee_id",
+		}
+		for k, v := range extra {
+			state[k] = v
+		}
+		return state
+	}
+
+	t.Run("always carries name and shortname", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, UserCustomAttributes().Schema, definition(nil))
+
+		input := userCustomAttributeDefinitionCreateInput(d)
+		if input["name"] != "Employee ID" {
+			t.Fatalf("expected name %q, got %v", "Employee ID", input["name"])
+		}
+		if input["shortname"] != "employee_id" {
+			t.Fatalf("expected shortname %q, got %v", "employee_id", input["shortname"])
+		}
+	})
+
+	t.Run("includes an explicit position", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, UserCustomAttributes().Schema, definition(map[string]interface{}{
+			"position": 27,
+		}))
+
+		if input := userCustomAttributeDefinitionCreateInput(d); input["position"] != 27 {
+			t.Fatalf("expected position 27, got %v", input["position"])
+		}
+	})
+
+	t.Run("omits an unset position", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, UserCustomAttributes().Schema, definition(nil))
+
+		if value, present := userCustomAttributeDefinitionCreateInput(d)["position"]; present {
+			t.Fatalf("expected an unset position to be omitted, got %v", value)
+		}
+	})
+}
+
+// TestUserCustomAttributeDefinitionUpdateInput covers the body sent when a
+// definition is updated. The API requires name and shortname on every update,
+// and only a literal null resets a position -- an omitted key leaves it alone.
+func TestUserCustomAttributeDefinitionUpdateInput(t *testing.T) {
+	t.Run("always carries the required fields", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, UserCustomAttributes().Schema, map[string]interface{}{
+			"name":      "Employee ID",
+			"shortname": "employee_id",
+		})
+
+		input := userCustomAttributeDefinitionUpdateInput(d)
+		if input["name"] != "Employee ID" {
+			t.Fatalf("expected name %q, got %v", "Employee ID", input["name"])
+		}
+		if input["shortname"] != "employee_id" {
+			t.Fatalf("expected shortname %q, got %v", "employee_id", input["shortname"])
+		}
+	})
+
+	t.Run("sends a configured position", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, UserCustomAttributes().Schema, map[string]interface{}{
+			"name":      "Employee ID",
+			"shortname": "employee_id",
+			"position":  27,
+		})
+
+		if input := userCustomAttributeDefinitionUpdateInput(d); input["position"] != 27 {
+			t.Fatalf("expected position 27, got %v", input["position"])
+		}
+	})
+
+	t.Run("sends an explicit null once the position is cleared", func(t *testing.T) {
+		// A position dropped from the configuration plans as 0, which is the
+		// state this update has to turn back into a null.
+		d := schema.TestResourceDataRaw(t, UserCustomAttributes().Schema, map[string]interface{}{
+			"name":      "Employee ID",
+			"shortname": "employee_id",
+			"position":  0,
+		})
+
+		input := userCustomAttributeDefinitionUpdateInput(d)
+		value, present := input["position"]
+		if !present {
+			t.Fatal("expected a cleared position to be sent, an omitted key leaves the old value in place")
+		}
+		if value != nil {
+			t.Fatalf("expected a cleared position to be sent as null, got %v", value)
+		}
+	})
+}
 
 func TestAccUserCustomAttributes_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
@@ -27,6 +125,51 @@ func testAccCheckUserCustomAttributesConfig() string {
 resource onelogin_user_custom_attributes test_attr {
   name      = "Test Attribute"
   shortname = "test_attr"
+}
+`
+}
+
+// TestAccUserCustomAttributes_position walks a definition through the lifecycle
+// reported in issue #224: created without a position, given one, then put back
+// to having none.
+func TestAccUserCustomAttributes_position(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { TestAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckUserCustomAttributesPositionConfig(""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("onelogin_user_custom_attributes.positioned_attr", "position", "0"),
+				),
+			},
+			{
+				Config: testAccCheckUserCustomAttributesPositionConfig("position = 27"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("onelogin_user_custom_attributes.positioned_attr", "position", "27"),
+				),
+			},
+			{
+				ResourceName:      "onelogin_user_custom_attributes.positioned_attr",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccCheckUserCustomAttributesPositionConfig(""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("onelogin_user_custom_attributes.positioned_attr", "position", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckUserCustomAttributesPositionConfig(position string) string {
+	return `
+resource onelogin_user_custom_attributes positioned_attr {
+  name      = "Positioned Attribute"
+  shortname = "positioned_attr"
+  ` + position + `
 }
 `
 }

--- a/onelogin/resource_onelogin_user_custom_attributes_test.go
+++ b/onelogin/resource_onelogin_user_custom_attributes_test.go
@@ -1,11 +1,57 @@
 package onelogin
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+// TestUserCustomAttributesNameIsOptional guards the schema shape. A value set on
+// one user needs no name, so requiring it made the documented usage -- and the
+// user_attr_value acceptance test below -- impossible to plan.
+func TestUserCustomAttributesNameIsOptional(t *testing.T) {
+	name := UserCustomAttributes().Schema["name"]
+
+	if name.Required {
+		t.Fatal("expected name to be optional, a user-value resource has no name to give")
+	}
+	if !name.Optional {
+		t.Fatal("expected name to be optional")
+	}
+}
+
+// TestCheckCustomAttributeDefinitionName covers the apply-time check that stands
+// in for the Required the schema can no longer carry.
+func TestCheckCustomAttributeDefinitionName(t *testing.T) {
+	t.Run("accepts a definition with a name", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, UserCustomAttributes().Schema, map[string]interface{}{
+			"name":      "Employee ID",
+			"shortname": "employee_id",
+		})
+
+		if err := checkCustomAttributeDefinitionName(d); err != nil {
+			t.Fatalf("expected the definition to be accepted, got %v", err)
+		}
+	})
+
+	t.Run("rejects a definition without a name", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, UserCustomAttributes().Schema, map[string]interface{}{
+			"shortname": "employee_id",
+		})
+
+		err := checkCustomAttributeDefinitionName(d)
+		if err == nil {
+			t.Fatal("expected a definition with no name to be rejected")
+		}
+		// The shortname is the only thing identifying which resource is at
+		// fault, so it has to appear in the message.
+		if !strings.Contains(err.Error(), "employee_id") {
+			t.Fatalf("expected the shortname in the error, got %v", err)
+		}
+	})
+}
 
 // TestValidCustomAttributePosition covers the plan-time guard on position. A
 // negative one reads differently in each payload builder -- sent as-is on

--- a/onelogin/resource_onelogin_user_custom_attributes_test.go
+++ b/onelogin/resource_onelogin_user_custom_attributes_test.go
@@ -7,6 +7,23 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+// TestValidCustomAttributePosition covers the plan-time guard on position. A
+// negative one reads differently in each payload builder -- sent as-is on
+// create, treated as a clear on update -- so it has to be rejected up front.
+func TestValidCustomAttributePosition(t *testing.T) {
+	for _, position := range []int{0, 1, 27} {
+		if _, errs := validCustomAttributePosition(position, "position"); len(errs) > 0 {
+			t.Fatalf("expected position %d to be accepted, got %v", position, errs)
+		}
+	}
+
+	for _, position := range []int{-1, -27} {
+		if _, errs := validCustomAttributePosition(position, "position"); len(errs) == 0 {
+			t.Fatalf("expected position %d to be rejected", position)
+		}
+	}
+}
+
 // TestUserCustomAttributeDefinitionCreateInput covers the "user_field" body sent
 // when a definition is created. OneLogin defaults position to null, so an unset
 // position has to stay out of the body rather than go in as a zero.


### PR DESCRIPTION
Fixes #224

Two changes to `onelogin_user_custom_attributes`: the `position` support #224 asks for, and a fix for `name` being required on a resource shape that has no name to give.

## 1. `position` on definitions

Definition CRUD ignored the `position` OneLogin returns, so ordering could not be configured and drift in it was invisible. It was dropped as unsupported in #138, but the API does accept it — as @ben0x1 verified against a sandbox tenant, and as the [create](https://developers.onelogin.com/api-docs/2/users/create-custom-attribute) and [update](https://developers.onelogin.com/api-docs/2/users/update-custom-attribute) docs confirm.

No SDK change is needed: the provider builds its own payload maps, and the generic `CreateCustomAttributes`/`UpdateCustomAttributes` take an `interface{}` body.

`position` is now an optional `TypeInt`, read during refresh and import. The API documents it as defaulting to `null` and never assigns one on its own, which is what makes the mapping work: positions start at 1, so the schema's zero value stands in for `null`, and a definition whose position nobody manages reads back as `0` — matching an absent config, so no perpetual drift. Same convention `onelogin_user_mappings` already uses. Negative values are rejected at plan time.

The two payload builders differ deliberately:

- **Create** omits `position` when unset, asking for the documented `null` default. Body stays wrapped in `user_field`.
- **Update** always sends it, as an explicit `null` once cleared — omitting the key would leave the old value in place, so a definition could never be put back to having none. This body is *not* wrapped; the update endpoint takes it flat, which is why the builders look asymmetric.

`name` and `shortname` now go out on every update too, both being required by the API, so a position-only change is no longer rejected for the missing fields.

## 2. `name` was required on both resource shapes

This resource does double duty: a definition, and a value set on one user. `name` was `Required: true` for both, so the documented user-value form could not pass a plan without a throwaway name. The `user_attr_value` case in this repo's own acceptance test omits `name` and so can never have run.

`name` is now optional, with definitions checked for it at apply. Not a `CustomizeDiff`, because the shapes are told apart by `user_id` — typically a reference to a user created in the same run, still unknown while planning. A plan-time check would read a user-value resource as a definition and demand a name it does not need. Supplying a name on a user-value resource stays harmless, so existing configs keep working.

## Testing

- `make test`, `go build`, `go vet`, `gofmt` all clean.
- Unit tests on both payload builders, the position validator, and the definition-name check. Verified the marshalled update body is literally `{"name":...,"position":null,"shortname":...}` — a struct with `json:"position,omitempty"` could not express that, which is why the map is hand-built.
- An acceptance test walks the lifecycle from #224: created with no position, given `27`, imported, then cleared back to none. **Not run** — no sandbox credentials available, so the round-trip against a live tenant is still unverified.