### PR TITLE
feat: look up several users at once by email in the users data source

### DIFF
--- a/docs/data-sources/onelogin_users.md
+++ b/docs/data-sources/onelogin_users.md
@@ -18,6 +18,49 @@ data onelogin_users example {
 }
 ```
 
+### Looking users up by email
+
+Resources that take user IDs — `onelogin_roles.users` among them — can be given
+the results of a lookup rather than IDs written out by hand. `emails` takes a
+list, so a whole membership can come from one data source:
+
+```hcl
+data onelogin_users engineering {
+  emails = [
+    "alice@example.com",
+    "bob@example.com",
+  ]
+}
+
+resource onelogin_roles engineering {
+  name  = "Engineering"
+  users = data.onelogin_users.engineering.users[*].id
+}
+```
+
+`users[*].id` is already a list of numbers, so it can be passed straight through;
+`ids` holds the same values as strings.
+
+Note that an email matching no user contributes nothing rather than failing. If a
+typo would be better caught than ignored, compare the counts:
+
+```hcl
+locals {
+  wanted = ["alice@example.com", "bob@example.com"]
+}
+
+data onelogin_users engineering {
+  emails = local.wanted
+}
+
+check "every_member_resolved" {
+  assert {
+    condition     = length(data.onelogin_users.engineering.users) == length(local.wanted)
+    error_message = "One or more emails in local.wanted matched no OneLogin user."
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -30,6 +73,11 @@ The following arguments are supported:
 
 * `email` - The user's email.
 
+* `emails` - A list of emails to look up at once. The API matches one email per
+  request, so each is queried in turn and the results combined, in the order
+  given, with duplicates removed. Any other argument set here applies to every
+  one of those queries. Conflicts with `email`.
+
 * `samaccountname` - The user's samaccount name
 
 * `external_id` - The user's external_id
@@ -38,4 +86,8 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-* `ids` - List of user's id
+* `ids` - List of user's id, as strings
+
+* `users` - List of the matching users, each with `id` (number), `username`,
+  `email`, `firstname`, `lastname`, `samaccountname`, `external_id`,
+  `directory_id` and `last_login`

--- a/ol_schema/user/user.go
+++ b/ol_schema/user/user.go
@@ -265,6 +265,13 @@ func QuerySchema() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Optional: true,
 		},
+		"emails": &schema.Schema{
+			Type:          schema.TypeList,
+			Optional:      true,
+			Elem:          &schema.Schema{Type: schema.TypeString},
+			ConflictsWith: []string{"email"},
+			Description:   "Look up several users at once by email. The API matches one email per request, so each is queried in turn and the results combined, in the order given. Conflicts with email",
+		},
 		"firstname": &schema.Schema{
 			Type:     schema.TypeString,
 			Optional: true,

--- a/onelogin/data_source_onelogin_users.go
+++ b/onelogin/data_source_onelogin_users.go
@@ -83,19 +83,45 @@ func dataSourceUsersRead(d *schema.ResourceData, m interface{}) error {
 		DirectoryID:    directoryID,
 	}
 
-	result, err := client.GetUsers(sdkQuery)
-	if err != nil {
-		log.Printf("[ERROR] There was a problem reading the users!")
-		log.Println(err)
-		return err
-	}
+	// The API matches a single email per request, so a list of them becomes one
+	// request each and the results are combined. Every other filter still
+	// applies to each, which keeps "these people, in this directory" expressible.
+	queries := usersQueriesForEmails(sdkQuery, emailsFromConfig(d))
 
-	// Parse the response
-	data, err := usersFromResponse(result)
-	if err != nil {
-		log.Printf("[WARNING] Invalid response format")
-		d.SetId("")
-		return err
+	data := make([]interface{}, 0)
+	seen := make(map[int]bool)
+	for _, q := range queries {
+		result, err := client.GetUsers(q)
+		if err != nil {
+			log.Printf("[ERROR] There was a problem reading the users!")
+			log.Println(err)
+			return err
+		}
+
+		// Parse the response
+		found, err := usersFromResponse(result)
+		if err != nil {
+			log.Printf("[WARNING] Invalid response format")
+			d.SetId("")
+			return err
+		}
+
+		// A user matching two of the emails, or two filters, is still one user.
+		for _, userData := range found {
+			user, ok := userData.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			id, ok := user["id"].(float64)
+			if !ok {
+				continue
+			}
+			if seen[int(id)] {
+				continue
+			}
+			seen[int(id)] = true
+			data = append(data, userData)
+		}
 	}
 
 	if len(data) == 0 {
@@ -166,8 +192,12 @@ func dataSourceUsersRead(d *schema.ResourceData, m interface{}) error {
 		userList = append(userList, u)
 	}
 
-	// Generate a hash for the ID
-	queryBytes, _ := json.Marshal(sdkQuery)
+	// Generate a hash for the ID. The emails go in alongside the query: they are
+	// not part of it, so two different email lists would otherwise hash alike.
+	queryBytes, _ := json.Marshal(struct {
+		Query  *models.UserQuery
+		Emails []string
+	}{sdkQuery, emailsFromConfig(d)})
 	queryHash := md5.Sum(queryBytes)
 	d.SetId(fmt.Sprintf("%x", queryHash))
 
@@ -175,6 +205,41 @@ func dataSourceUsersRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("users", userList)
 
 	return nil
+}
+
+// emailsFromConfig reads the "emails" filter, dropping blanks so an interpolated
+// value that came out empty does not turn into a query for every user.
+func emailsFromConfig(d *schema.ResourceData) []string {
+	raw, ok := d.Get("emails").([]interface{})
+	if !ok {
+		return nil
+	}
+
+	emails := make([]string, 0, len(raw))
+	for _, v := range raw {
+		if email, ok := v.(string); ok && email != "" {
+			emails = append(emails, email)
+		}
+	}
+	return emails
+}
+
+// usersQueriesForEmails fans a query out over a list of emails, one query each,
+// leaving every other filter in place. With no emails the query is returned
+// unchanged, so the single-email and unfiltered cases are untouched.
+func usersQueriesForEmails(base *models.UserQuery, emails []string) []*models.UserQuery {
+	if len(emails) == 0 {
+		return []*models.UserQuery{base}
+	}
+
+	queries := make([]*models.UserQuery, 0, len(emails))
+	for _, email := range emails {
+		q := *base
+		emailVal := email
+		q.Email = &emailVal
+		queries = append(queries, &q)
+	}
+	return queries
 }
 
 func HashQuery(query *userschema.UserQuery) [16]byte {

--- a/onelogin/data_source_onelogin_users_emails_test.go
+++ b/onelogin/data_source_onelogin_users_emails_test.go
@@ -1,0 +1,90 @@
+package onelogin
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/onelogin/onelogin-go-sdk/v4/pkg/onelogin/models"
+	userschema "github.com/onelogin/terraform-provider-onelogin/ol_schema/user"
+)
+
+// TestEmailsFromConfig covers reading the emails filter. A blank entry is
+// dropped: an interpolated value that came out empty would otherwise become a
+// query with no email set, which matches every user in the tenant.
+func TestEmailsFromConfig(t *testing.T) {
+	t.Run("reads the emails in the order given", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, userschema.QuerySchema(), map[string]interface{}{
+			"emails": []interface{}{"alice@example.com", "bob@example.com"},
+		})
+
+		emails := emailsFromConfig(d)
+		if len(emails) != 2 || emails[0] != "alice@example.com" || emails[1] != "bob@example.com" {
+			t.Fatalf("expected both emails in order, got %v", emails)
+		}
+	})
+
+	t.Run("drops blank entries", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, userschema.QuerySchema(), map[string]interface{}{
+			"emails": []interface{}{"alice@example.com", ""},
+		})
+
+		if emails := emailsFromConfig(d); len(emails) != 1 || emails[0] != "alice@example.com" {
+			t.Fatalf("expected the blank to be dropped, got %v", emails)
+		}
+	})
+
+	t.Run("reports none when unset", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, userschema.QuerySchema(), map[string]interface{}{})
+
+		if emails := emailsFromConfig(d); len(emails) != 0 {
+			t.Fatalf("expected no emails, got %v", emails)
+		}
+	})
+}
+
+// TestUsersQueriesForEmails covers the fan-out. Every other filter has to
+// survive onto each query, or "these people, in this directory" would silently
+// widen to "these people, anywhere".
+func TestUsersQueriesForEmails(t *testing.T) {
+	directory := "42"
+	base := &models.UserQuery{DirectoryID: &directory}
+
+	t.Run("returns the query untouched when there are no emails", func(t *testing.T) {
+		queries := usersQueriesForEmails(base, nil)
+
+		if len(queries) != 1 || queries[0] != base {
+			t.Fatalf("expected the original query, got %v", queries)
+		}
+	})
+
+	t.Run("builds one query per email", func(t *testing.T) {
+		queries := usersQueriesForEmails(base, []string{"alice@example.com", "bob@example.com"})
+
+		if len(queries) != 2 {
+			t.Fatalf("expected 2 queries, got %d", len(queries))
+		}
+		for i, want := range []string{"alice@example.com", "bob@example.com"} {
+			if queries[i].Email == nil || *queries[i].Email != want {
+				t.Fatalf("query %d: expected email %q, got %v", i, want, queries[i].Email)
+			}
+		}
+	})
+
+	t.Run("carries the other filters onto every query", func(t *testing.T) {
+		queries := usersQueriesForEmails(base, []string{"alice@example.com", "bob@example.com"})
+
+		for i, q := range queries {
+			if q.DirectoryID == nil || *q.DirectoryID != directory {
+				t.Fatalf("query %d lost the directory filter: %v", i, q.DirectoryID)
+			}
+		}
+	})
+
+	t.Run("leaves the base query unmodified", func(t *testing.T) {
+		usersQueriesForEmails(base, []string{"alice@example.com"})
+
+		if base.Email != nil {
+			t.Fatalf("expected the base query to be untouched, got email %v", *base.Email)
+		}
+	})
+}


### PR DESCRIPTION
Fixes #216

## Problem

`onelogin_roles.users` takes user IDs, and as @kdeyko puts it, humans rarely operate with IDs. The `onelogin_users` data source could already resolve an email to an ID — added in #217 — but `email` matches one value, so a role with a dozen members meant a dozen data source blocks and a `concat`.

## Fix

`emails` takes a list:

```hcl
data onelogin_users engineering {
  emails = ["alice@example.com", "bob@example.com"]
}

resource onelogin_roles engineering {
  name  = "Engineering"
  users = data.onelogin_users.engineering.users[*].id
}
```

`users[*].id` is already a list of numbers, so it feeds `roles.users` directly with no conversion.

The API matches a single email per request, so each is queried in turn and the results combined, in the order given, with duplicates removed — one user matching two filters is still one user. Every other argument applies to each query, so `emails` + `directory_id` keeps meaning "these people, in this directory" rather than silently widening to "these people, anywhere". `ConflictsWith: email`, since supporting both at once would only raise the question of what their combination means.

Two details worth flagging in review:

- **Blank entries are dropped.** An interpolated email that came out empty would otherwise become a query with no email set, which matches the entire tenant — a quiet way to put every user in a role.
- **The data source ID now hashes the emails alongside the query.** They are not part of the `UserQuery` object, so two different email lists would previously have produced the same ID.

## Why not accept emails on `onelogin_roles` directly

That was the literal request, and it is a trap. The API returns members as IDs, so a config holding emails would need a reverse lookup per member on every refresh just to decide whether anything had changed, or `users` would have to become `Computed` — which would make `users = []` indistinguishable from "unset" and leave no way to remove the last member. Resolving through a data source keeps the resource honest about what the API actually stores.

## Testing

- `make test`, `go build`, `go vet`, `gofmt` clean.
- Unit tests over both helpers: ordering, blank-dropping, the unset case, one-query-per-email, other filters surviving the fan-out, and the base query not being mutated.
- **No acceptance test run** — no sandbox credentials in this environment, so the multi-email fan-out is unverified against a live tenant.