### PR TITLE
ci: allow a release to be rebuilt without re-creating it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,16 @@ name: Release
 on:
   release:
     types: [published]
+  # Rebuild a tag that already has a release. The published event is delivered
+  # once and never again, so a release whose build failed cannot otherwise be
+  # retried: the only recourse is deleting and re-creating the release, which
+  # destroys whatever assets it does have.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build, e.g. v0.14.0'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -15,6 +25,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # A release event already points at the tag. A dispatch defaults to
+          # the branch it was started from, which would build main and stamp it
+          # with whatever version main describes to, so the tag has to be named.
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Go
         uses: actions/setup-go@v4

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,10 +35,14 @@ signs:
     args: ["--batch", "-u", "{{ .Env.GPG_FINGERPRINT }}", "--output", "${signature}", "--detach-sign", "${artifact}"]
 
 release:
-  # A rebuild uploads artifacts a release may already hold, which is an error
-  # otherwise. Replacing them is safe: builds are reproducible here, pinned by
-  # mod_timestamp to the commit and built with -trimpath.
-  mode: replace
+  # A rebuild uploads artifacts the release may already hold, which fails with
+  # a 422. This deletes the conflicting asset and retries, and only on that
+  # 422, so a first release pays nothing for it. Replacing is safe here:
+  # mod_timestamp pins to the commit and builds use -trimpath.
+  #
+  # Not "mode: replace" — that governs the release *notes*, and would overwrite
+  # a hand-written body with the generated changelog on every rebuild.
+  replace_existing_artifacts: true
 
 changelog:
   sort: asc

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,6 +34,12 @@ signs:
   - artifacts: checksum
     args: ["--batch", "-u", "{{ .Env.GPG_FINGERPRINT }}", "--output", "${signature}", "--detach-sign", "${artifact}"]
 
+release:
+  # A rebuild uploads artifacts a release may already hold, which is an error
+  # otherwise. Replacing them is safe: builds are reproducible here, pinned by
+  # mod_timestamp to the commit and built with -trimpath.
+  mode: replace
+
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
## Problem

`release.yml` ran only on `release: published`. That event is delivered once and never again, so a release whose build failed could not be retried — the only recourse was deleting and re-creating the release, which destroys whatever assets it already has.

This is not hypothetical. During the GitHub Actions incident on 2026-08-06:

- v0.13.0 published at 15:55; its build was cancelled mid-outage. The release sat with **0 assets for nine hours**.
- Re-running the failed workflow run eventually produced the assets — but the Terraform Registry ingests on that same `release: published` event, and it had already fired while the release was empty. Assets arriving later fire no new event, so **v0.13.0 stayed invisible to `terraform init`** even though GitHub showed a complete, healthy release.
- The only fix was deleting and re-creating the release so a fresh event arrived *after* the assets existed. v0.14.0 hit the identical problem and needed the same treatment.

With a dispatch trigger, both would have been one click.

## Changes

**`workflow_dispatch` with a required `tag` input**, and the checkout pinned to it:

```yaml
ref: ${{ inputs.tag || github.ref }}
```

A dispatch defaults to the branch it was started from. Without naming the tag, a rebuild would build `main` and stamp it with whatever version `git describe` resolves to — building the wrong code under a release version is worse than not building at all. On a `release` event `inputs.tag` is empty and `github.ref` is already the tag, so that path is unchanged.

**`release.mode: replace` in `.goreleaser.yaml`.** A rebuild uploads artifacts the release may already hold, which is an error under the default. Replacing is safe here because the build is reproducible: `mod_timestamp` is pinned to the commit and `-trimpath` is set.

That second change is the one worth a reviewer's attention — it alters behaviour for normal releases too, though for a fresh release with no assets there is nothing to replace. Happy to drop it and accept that dispatch only works against a release with no assets, if you would rather keep the blast radius smaller.

## Testing

- Both files verified as valid YAML; triggers parse as `release` + `workflow_dispatch`, and the `ref` expression is in place.
- `goreleaser check` not run — the CLI is not installed locally.
- **The dispatch path is untested end to end.** It cannot be exercised until this is on `main`, since `workflow_dispatch` only appears once the trigger exists on the default branch. First real use will be the next release that needs a rebuild.