### PR TITLE
Manage post_logout_redirect_uri on OIDC apps

### DIFF
--- a/docs/resources/onelogin_oidc_apps.md
+++ b/docs/resources/onelogin_oidc_apps.md
@@ -24,7 +24,7 @@ resource onelogin_oidc_apps my_oidc_app {
   description = "example OIDC app"
 
   configuration = {
-    post_logout_redirect_uri = ""
+    post_logout_redirect_uri = "https://www.example.com/logout"
     login_url = "https://www.example.com"
     oidc_application_type = 0
     redirect_uri = "https://example.com/example"
@@ -98,7 +98,7 @@ The following arguments are supported:
 
 
 * `configuration` - OIDC settings that control the authentication flow e.g. redirect urls and token settings.
-  * `post_logout_redirect_uri` - (Optional) The redirect_uri for the app to send the user to after logout.
+  * `post_logout_redirect_uri` - (Optional) The redirect_uri for the app to send the user to after logout. To allow more than one, give a single string with the URIs separated by newlines or commas. Set it to `""` to remove every URI from the app. Omitting the attribute entirely leaves whatever the app already has in place, so that removing it from your configuration is not the same as clearing it.
 
   * `redirect_uri` - (Optional) The redirect_uri for the OIDC flow. Will be computed by API if not given.
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.4.3
 	github.com/onelogin/onelogin-go-sdk v1.1.22
-	github.com/onelogin/onelogin-go-sdk/v4 v4.10.0
+	github.com/onelogin/onelogin-go-sdk/v4 v4.12.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -378,6 +378,10 @@ github.com/onelogin/onelogin-go-sdk v1.1.22 h1:6EQkQLY3TVfRwS25zkIk7i069qTEbe6MC
 github.com/onelogin/onelogin-go-sdk v1.1.22/go.mod h1:GM0+ziS1fhnPnxC2fLzVloxn+VzBwzXKkIaDOPoE5GU=
 github.com/onelogin/onelogin-go-sdk/v4 v4.10.0 h1:vNONzH89TtLcfXpjJXwXy5iA4ztBzifB9hkDZSKbggs=
 github.com/onelogin/onelogin-go-sdk/v4 v4.10.0/go.mod h1:2F3mvTga3mVU4HJNH6OQ00OjJDY3JmLcumJIeMNYwNg=
+github.com/onelogin/onelogin-go-sdk/v4 v4.11.0 h1:X1zBmZctLsd/TWPDZuQ1Bsq4hOII7528cJz1Exek0LI=
+github.com/onelogin/onelogin-go-sdk/v4 v4.11.0/go.mod h1:2F3mvTga3mVU4HJNH6OQ00OjJDY3JmLcumJIeMNYwNg=
+github.com/onelogin/onelogin-go-sdk/v4 v4.12.0 h1:wZYM1h1VO0mAcF6x2Ud1HkgENii1ViIHgWXtbiI7eto=
+github.com/onelogin/onelogin-go-sdk/v4 v4.12.0/go.mod h1:2F3mvTga3mVU4HJNH6OQ00OjJDY3JmLcumJIeMNYwNg=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=

--- a/ol_schema/app/configuration/configuration.go
+++ b/ol_schema/app/configuration/configuration.go
@@ -12,12 +12,13 @@ import (
 // omitting timeout fields when they are not explicitly set, to avoid overriding
 // API defaults with 0 values during updates.
 type CustomConfigurationOpenId struct {
-	RedirectURI                   string `json:"redirect_uri,omitempty"`
-	LoginURL                      string `json:"login_url,omitempty"`
-	OidcApplicationType           int    `json:"oidc_application_type,omitempty"`
-	TokenEndpointAuthMethod       int    `json:"token_endpoint_auth_method,omitempty"`
-	AccessTokenExpirationMinutes  *int   `json:"access_token_expiration_minutes,omitempty"`
-	RefreshTokenExpirationMinutes *int   `json:"refresh_token_expiration_minutes,omitempty"`
+	RedirectURI                   string  `json:"redirect_uri,omitempty"`
+	PostLogoutRedirectURI         *string `json:"post_logout_redirect_uri,omitempty"`
+	LoginURL                      string  `json:"login_url,omitempty"`
+	OidcApplicationType           int     `json:"oidc_application_type,omitempty"`
+	TokenEndpointAuthMethod       int     `json:"token_endpoint_auth_method,omitempty"`
+	AccessTokenExpirationMinutes  *int    `json:"access_token_expiration_minutes,omitempty"`
+	RefreshTokenExpirationMinutes *int    `json:"refresh_token_expiration_minutes,omitempty"`
 }
 
 func validSignatureAlgorithm(val interface{}, key string) (warns []string, errs []error) {
@@ -89,6 +90,14 @@ func Inflate(s map[string]interface{}) (interface{}, error) {
 		customOidc.RedirectURI = getString(s["redirect_uri"])
 		customOidc.LoginURL = getString(s["login_url"])
 
+		// Present-but-empty means "remove every URI", which is a different
+		// request from leaving the attribute out and is why the field is a
+		// pointer. Only an absent key leaves the app's URIs alone.
+		if val, exists := s["post_logout_redirect_uri"]; exists {
+			uris := getString(val)
+			customOidc.PostLogoutRedirectURI = &uris
+		}
+
 		// Handle timeout fields specially - only set them if explicitly provided and non-empty
 		// This prevents overriding existing API values with 0 when fields are not specified
 		if customOidc.RefreshTokenExpirationMinutes, err = handleTimeoutField(s, "refresh_token_expiration_minutes"); err != nil {
@@ -147,6 +156,10 @@ func FlattenOIDC(config models.ConfigurationOpenId) map[string]interface{} {
 	// Add non-empty fields
 	if config.RedirectURI != "" {
 		tfOut["redirect_uri"] = config.RedirectURI
+	}
+
+	if config.PostLogoutRedirectURI != nil && *config.PostLogoutRedirectURI != "" {
+		tfOut["post_logout_redirect_uri"] = *config.PostLogoutRedirectURI
 	}
 
 	if config.LoginURL != "" {
@@ -208,6 +221,16 @@ func Flatten(config map[string]interface{}) map[string]interface{} {
 		// Handle OIDC fields
 		if val, ok := config["redirect_uri"].(string); ok && val != "" {
 			tfOut["redirect_uri"] = val
+		}
+
+		// Deliberately keeps an empty value, unlike the fields around it. The
+		// API returns null for an app that never had URIs and "" for one whose
+		// URIs were cleared, and the type assertion already separates the two:
+		// null fails it. Dropping "" as well would leave state without a key
+		// the practitioner's configuration still has, and the plan would never
+		// go quiet.
+		if val, ok := config["post_logout_redirect_uri"].(string); ok {
+			tfOut["post_logout_redirect_uri"] = val
 		}
 
 		if val, ok := config["login_url"].(string); ok && val != "" {

--- a/ol_schema/app/configuration/configuration.go
+++ b/ol_schema/app/configuration/configuration.go
@@ -158,7 +158,11 @@ func FlattenOIDC(config models.ConfigurationOpenId) map[string]interface{} {
 		tfOut["redirect_uri"] = config.RedirectURI
 	}
 
-	if config.PostLogoutRedirectURI != nil && *config.PostLogoutRedirectURI != "" {
+	// Keeps an empty value, matching Flatten below. The pointer draws the same
+	// line the type assertion draws there: nil is an app that never had URIs,
+	// while a pointer to "" is one whose URIs were cleared, and state has to
+	// keep the latter or the plan never goes quiet.
+	if config.PostLogoutRedirectURI != nil {
 		tfOut["post_logout_redirect_uri"] = *config.PostLogoutRedirectURI
 	}
 

--- a/ol_schema/app/configuration/configuration_test.go
+++ b/ol_schema/app/configuration/configuration_test.go
@@ -275,6 +275,24 @@ func TestFlattenConfiguration(t *testing.T) {
 				"access_token_expiration_minutes":  "2",
 			},
 		},
+		"keeps a cleared post_logout_redirect_uri so the plan converges": {
+			InputData: models.ConfigurationOpenId{
+				RedirectURI:           "test",
+				PostLogoutRedirectURI: strPtr(""),
+			},
+			ExpectedOutput: map[string]interface{}{
+				"redirect_uri":             "test",
+				"post_logout_redirect_uri": "",
+			},
+		},
+		"drops a nil post_logout_redirect_uri, which means the app never had URIs": {
+			InputData: models.ConfigurationOpenId{
+				RedirectURI: "test",
+			},
+			ExpectedOutput: map[string]interface{}{
+				"redirect_uri": "test",
+			},
+		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/ol_schema/app/configuration/configuration_test.go
+++ b/ol_schema/app/configuration/configuration_test.go
@@ -1,6 +1,7 @@
 package appconfigurationschema
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -31,6 +32,20 @@ func TestInflateConfiguration(t *testing.T) {
 				OidcApplicationType:           2,
 				TokenEndpointAuthMethod:       2,
 				AccessTokenExpirationMinutes:  intPtr(2),
+			},
+		},
+		"carries post_logout_redirect_uri through to the request body": {
+			ResourceData: map[string]interface{}{
+				"redirect_uri":               "https://example.com/callback",
+				"post_logout_redirect_uri":   "https://example.com/logout\nhttps://example.com/bye",
+				"oidc_application_type":      "0",
+				"token_endpoint_auth_method": "1",
+			},
+			ExpectedOutput: CustomConfigurationOpenId{
+				RedirectURI:             "https://example.com/callback",
+				PostLogoutRedirectURI:   strPtr("https://example.com/logout\nhttps://example.com/bye"),
+				OidcApplicationType:     0,
+				TokenEndpointAuthMethod: 1,
 			},
 		},
 		"handles OIDC app config with only redirect_uri (no timeout fields)": {
@@ -198,6 +213,7 @@ func TestInflateConfiguration(t *testing.T) {
 				} else if customOidcConfig, ok := test.ExpectedOutput.(CustomConfigurationOpenId); ok {
 					if customOidcResult, ok := subj.(CustomConfigurationOpenId); ok {
 						assert.Equal(t, customOidcConfig.RedirectURI, customOidcResult.RedirectURI)
+						assert.Equal(t, customOidcConfig.PostLogoutRedirectURI, customOidcResult.PostLogoutRedirectURI)
 						assert.Equal(t, customOidcConfig.LoginURL, customOidcResult.LoginURL)
 						assert.Equal(t, customOidcConfig.OidcApplicationType, customOidcResult.OidcApplicationType)
 						assert.Equal(t, customOidcConfig.TokenEndpointAuthMethod, customOidcResult.TokenEndpointAuthMethod)
@@ -242,6 +258,7 @@ func TestFlattenConfiguration(t *testing.T) {
 		"creates and returns the address of an AppConfiguration struct for a OIDC app": {
 			InputData: models.ConfigurationOpenId{
 				RedirectURI:                   "test",
+				PostLogoutRedirectURI:         strPtr("https://example.com/logout"),
 				RefreshTokenExpirationMinutes: 2,
 				LoginURL:                      "test",
 				OidcApplicationType:           2,
@@ -250,6 +267,7 @@ func TestFlattenConfiguration(t *testing.T) {
 			},
 			ExpectedOutput: map[string]interface{}{
 				"redirect_uri":                     "test",
+				"post_logout_redirect_uri":         "https://example.com/logout",
 				"refresh_token_expiration_minutes": "2",
 				"login_url":                        "test",
 				"oidc_application_type":            "2",
@@ -271,6 +289,45 @@ func TestFlattenGenericConfiguration(t *testing.T) {
 		InputData      map[string]interface{}
 		ExpectedOutput map[string]interface{}
 	}{
+		"flattens OIDC configuration from API response": {
+			InputData: map[string]interface{}{
+				"redirect_uri":                     "https://example.com/callback",
+				"post_logout_redirect_uri":         "https://example.com/logout",
+				"login_url":                        "https://example.com/login",
+				"oidc_application_type":            float64(0), // JSON unmarshaling makes numbers float64
+				"token_endpoint_auth_method":       float64(1),
+				"access_token_expiration_minutes":  float64(10),
+				"refresh_token_expiration_minutes": float64(20),
+			},
+			ExpectedOutput: map[string]interface{}{
+				"redirect_uri":                     "https://example.com/callback",
+				"post_logout_redirect_uri":         "https://example.com/logout",
+				"login_url":                        "https://example.com/login",
+				"token_endpoint_auth_method":       "1",
+				"access_token_expiration_minutes":  "10",
+				"refresh_token_expiration_minutes": "20",
+				// oidc_application_type is 0, which Flatten drops as a zero value
+			},
+		},
+		"keeps a cleared post_logout_redirect_uri so the plan converges": {
+			InputData: map[string]interface{}{
+				"redirect_uri":             "https://example.com/callback",
+				"post_logout_redirect_uri": "",
+			},
+			ExpectedOutput: map[string]interface{}{
+				"redirect_uri":             "https://example.com/callback",
+				"post_logout_redirect_uri": "",
+			},
+		},
+		"drops a null post_logout_redirect_uri, which means the app never had URIs": {
+			InputData: map[string]interface{}{
+				"redirect_uri":             "https://example.com/callback",
+				"post_logout_redirect_uri": nil,
+			},
+			ExpectedOutput: map[string]interface{}{
+				"redirect_uri": "https://example.com/callback",
+			},
+		},
 		"flattens comprehensive SAML configuration from API response": {
 			InputData: map[string]interface{}{
 				"signature_algorithm": "SHA-256",
@@ -387,4 +444,62 @@ func TestValidSignatureAlgorithm(t *testing.T) {
 			assert.Equal(t, test.ExpectedOutput, errs)
 		})
 	}
+}
+
+// TestInflateOIDCPostLogoutSerialization locks the wire contract for
+// post_logout_redirect_uri. The API treats a present key as an assignment, so
+// the three states have to stay distinct on the way out: an attribute the
+// practitioner never wrote must stay off the request body entirely rather than
+// clearing what the app already has, while one they deliberately blanked has to
+// reach the API as "" so the URIs are removed.
+func TestInflateOIDCPostLogoutSerialization(t *testing.T) {
+	tests := map[string]struct {
+		ResourceData map[string]interface{}
+		ExpectKey    bool
+		ExpectValue  string
+	}{
+		"omits the key when the practitioner does not set it": {
+			ResourceData: map[string]interface{}{"redirect_uri": "https://example.com/callback"},
+			ExpectKey:    false,
+		},
+		"sends an empty value when the practitioner blanks it, to clear the URIs": {
+			ResourceData: map[string]interface{}{
+				"redirect_uri":             "https://example.com/callback",
+				"post_logout_redirect_uri": "",
+			},
+			ExpectKey:   true,
+			ExpectValue: "",
+		},
+		"sends the key when the practitioner sets a value": {
+			ResourceData: map[string]interface{}{
+				"redirect_uri":             "https://example.com/callback",
+				"post_logout_redirect_uri": "https://example.com/logout",
+			},
+			ExpectKey:   true,
+			ExpectValue: "https://example.com/logout",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			subj, err := Inflate(test.ResourceData)
+			assert.NoError(t, err)
+
+			body, err := json.Marshal(subj)
+			assert.NoError(t, err)
+
+			var got map[string]interface{}
+			assert.NoError(t, json.Unmarshal(body, &got))
+
+			val, present := got["post_logout_redirect_uri"]
+			assert.Equal(t, test.ExpectKey, present, "request body was %s", body)
+			if test.ExpectKey {
+				assert.Equal(t, test.ExpectValue, val)
+			}
+		})
+	}
+}
+
+// strPtr mirrors intPtr for the pointer-valued string fields.
+func strPtr(val string) *string {
+	return &val
 }

--- a/vendor/github.com/onelogin/onelogin-go-sdk/v4/pkg/onelogin/models/app.go
+++ b/vendor/github.com/onelogin/onelogin-go-sdk/v4/pkg/onelogin/models/app.go
@@ -49,13 +49,24 @@ type Certificate struct {
 	Value string `json:"value"`
 }
 
+// ConfigurationOpenId holds the OIDC settings on an app's Configuration tab.
+//
+// PostLogoutRedirectURI carries one or more URIs as a single newline- or
+// comma-separated string, matching how the API stores the connector's
+// post_logout_redirect_uri parameter. It is a pointer because the API treats a
+// present key as an assignment, giving three distinct requests:
+//
+//	nil            omit the key; leave the app's existing URIs alone
+//	pointer to ""  send ""; clear every URI configured on the app
+//	pointer to "…" send the value; replace the app's URIs
 type ConfigurationOpenId struct {
-	RedirectURI                   string `json:"redirect_uri"`
-	LoginURL                      string `json:"login_url"`
-	OidcApplicationType           int    `json:"oidc_application_type"`
-	TokenEndpointAuthMethod       int    `json:"token_endpoint_auth_method"`
-	AccessTokenExpirationMinutes  int    `json:"access_token_expiration_minutes"`
-	RefreshTokenExpirationMinutes int    `json:"refresh_token_expiration_minutes"`
+	RedirectURI                   string  `json:"redirect_uri"`
+	PostLogoutRedirectURI         *string `json:"post_logout_redirect_uri,omitempty"`
+	LoginURL                      string  `json:"login_url"`
+	OidcApplicationType           int     `json:"oidc_application_type"`
+	TokenEndpointAuthMethod       int     `json:"token_endpoint_auth_method"`
+	AccessTokenExpirationMinutes  int     `json:"access_token_expiration_minutes"`
+	RefreshTokenExpirationMinutes int     `json:"refresh_token_expiration_minutes"`
 }
 
 type ConfigurationSAML struct {

--- a/vendor/github.com/onelogin/onelogin-go-sdk/v4/pkg/onelogin/models/role.go
+++ b/vendor/github.com/onelogin/onelogin-go-sdk/v4/pkg/onelogin/models/role.go
@@ -9,15 +9,6 @@ type RoleQuery struct {
 	Cursor string `json:"cursor,omitempty"`
 }
 
-// initSlice ensures that a nil slice is initialized as an empty slice
-// This helper is needed for the Role.MarshalJSON method
-func initSlice(s []int32) []int32 {
-	if s == nil {
-		return []int32{}
-	}
-	return s
-}
-
 // Role represents the Role resource in OneLogin
 type Role struct {
 	ID     *int32  `json:"id,omitempty"`
@@ -27,24 +18,40 @@ type Role struct {
 	Users  []int32 `json:"users"`
 }
 
-// MarshalJSON provides custom JSON marshaling to ensure empty arrays are included in the JSON output
-func (r *Role) MarshalJSON() ([]byte, error) {
-	// Create a map to hold the serialized fields
+// MarshalJSON keeps a nil membership slice out of the request body entirely,
+// while still sending an explicitly empty one.
+//
+// The API replaces memberships wholesale for any array it receives, so the two
+// have to stay distinct or a caller updating one field silently wipes the rest:
+//
+//	nil            omit the key; leave those memberships alone
+//	[]int32{}      send []; remove every membership
+//	[]int32{1, 2}  send the ids; replace the memberships
+//
+// The struct tags cannot express this on their own. Without omitempty a nil
+// slice marshals to null, and with it an explicitly empty slice disappears too,
+// which is why this is hand-rolled. The receiver is deliberately a value so that
+// json.Marshal treats a Role and a *Role the same way.
+func (r Role) MarshalJSON() ([]byte, error) {
 	m := make(map[string]interface{})
-	
-	// Add ID and Name if they are not nil
+
 	if r.ID != nil {
 		m["id"] = *r.ID
 	}
 	if r.Name != nil {
 		m["name"] = *r.Name
 	}
-	
-	// Always include the arrays, even if they're nil (as empty arrays)
-	m["admins"] = initSlice(r.Admins)
-	m["apps"] = initSlice(r.Apps)
-	m["users"] = initSlice(r.Users)
-	
+
+	if r.Admins != nil {
+		m["admins"] = r.Admins
+	}
+	if r.Apps != nil {
+		m["apps"] = r.Apps
+	}
+	if r.Users != nil {
+		m["users"] = r.Users
+	}
+
 	return json.Marshal(m)
 }
 

--- a/vendor/github.com/onelogin/onelogin-go-sdk/v4/pkg/onelogin/version.go
+++ b/vendor/github.com/onelogin/onelogin-go-sdk/v4/pkg/onelogin/version.go
@@ -1,3 +1,3 @@
 package onelogin
 
-const Version = "4.10.0"
+const Version = "4.12.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -469,7 +469,7 @@ github.com/onelogin/onelogin-go-sdk/pkg/services/olhttp
 github.com/onelogin/onelogin-go-sdk/pkg/services/smarthooks
 github.com/onelogin/onelogin-go-sdk/pkg/services/smarthooks/envs
 github.com/onelogin/onelogin-go-sdk/pkg/utils
-# github.com/onelogin/onelogin-go-sdk/v4 v4.10.0
+# github.com/onelogin/onelogin-go-sdk/v4 v4.12.0
 ## explicit; go 1.18
 github.com/onelogin/onelogin-go-sdk/v4/pkg/onelogin
 github.com/onelogin/onelogin-go-sdk/v4/pkg/onelogin/api


### PR DESCRIPTION
Closes https://github.com/onelogin/onelogin-go-sdk/issues/116. Follows on from onelogin/onelogin-go-sdk#117, which added the field to the SDK; this is the half that makes it reachable from Terraform.

## Problem

`post_logout_redirect_uri` has been documented as a supported `configuration` attribute for `onelogin_oidc_apps` for some time, but it has never worked. Nothing in the provider read or wrote it:

- **Write** — `Inflate` builds its own `CustomConfigurationOpenId`, which had no such field, so the key was dropped before the request body was built.
- **Read** — `oidcAppRead` calls the map-based `Flatten`, which copied six keys and not this one.

Because `configuration` is an untyped `TypeMap`, setting the attribute raised no error. It was silently discarded and then showed up as a plan that never went quiet.

## Fix

Wire the attribute through `Inflate`, `Flatten` and `FlattenOIDC`, and vendor SDK v4.12.0.

The attribute has three states and all three have to survive the round trip:

| Configuration | Request | Effect |
| --- | --- | --- |
| attribute absent | key omitted | app's URIs left alone |
| `post_logout_redirect_uri = ""` | `"post_logout_redirect_uri": ""` | every URI removed |
| `post_logout_redirect_uri = "https://…"` | the value | URIs replaced |

Note that removing the attribute from your configuration is therefore not the same as clearing it — same as the timeout fields already behave here. The docs say so explicitly now.

Two details worth a reviewer's attention:

- The request field is a `*string`, not a `string`. With `omitempty` on a bare string there is no way to ask for a clear, because `""` is indistinguishable from unset and gets dropped.
- `Flatten` deliberately **keeps** an empty value for this one key, unlike the fields around it. The API returns `null` for an app that never had URIs and `""` for one whose URIs were cleared, and the `.(string)` assertion already separates those — `null` fails it. Dropping `""` too would leave state without a key the configuration still has.

To allow more than one URI, give a single string with them separated by newlines or commas. That is how the connector parameter is stored, and it is not guessable from the type.

## Test

- `TestInflateOIDCPostLogoutSerialization` marshals the request body and asserts the key is absent when unset, present as `""` when blanked, and present with the value when set. Verified it fails if the tag loses `omitempty`.
- Round-trip cases in `TestFlattenGenericConfiguration` for the cleared (`""`) and never-set (`null`) responses.
- Added the first OIDC case to `TestFlattenGenericConfiguration`, which covered only SAML — the live read path for OIDC apps had no coverage at all, which is a fair part of why this went unnoticed.
- `go build`, `go vet`, `go test ./...` all clean. `TestAccPreCheck` fails for want of `ONELOGIN_CLIENT_ID`; it fails identically on `main`.

## Files

- `ol_schema/app/configuration/configuration.go` — the wiring
- `ol_schema/app/configuration/configuration_test.go` — coverage
- `docs/resources/onelogin_oidc_apps.md` — multi-URI encoding and clear-vs-omit; the example set the attribute to `""`, which now means "clear"
- `go.mod` / `go.sum` / `vendor/` — SDK v4.12.0, generated, no hand edits

## Also in the SDK bump

The vendored version is v4.12.0 rather than the v4.11.0 that added the field, so this also picks up onelogin/onelogin-go-sdk#118 — `UpdateRole` was sending empty `admins`/`apps`/`users` arrays the caller never set, and the API removed those memberships, so renaming a role through `onelogin_roles` silently dropped every app, user and admin on it.

That fix needs no provider change: `ol_schema/role/role.go` already leaves the slices nil unless the key is present and builds a non-nil empty slice for an empty list, so it was written for these semantics all along. Confirmed end to end through the provider's own `Inflate` after re-vendoring:

| Terraform action | Request body |
| --- | --- |
| rename only | `{"name":"Renamed"}` — memberships untouched |
| `apps = []` | `{"apps":[],"name":"Renamed"}` — cleared |
| `apps = [7,9]` | `{"apps":[7,9],"name":"Renamed"}` — replaced |

Practitioners who added `ignore_changes` on `apps`/`users`/`admins` to work around this can drop it once this ships; it never actually helped, since the wipe was introduced after the diff.

## Rollback

Revert the PR. The attribute returns to being silently ignored, which is where it has been all along; no state migration is involved.

Thanks to @karvsb, who reported this and wrote the original SDK patch.
