### PR TITLE
fix: stop rewriting API nulls as empty strings on app update

### DIFF
--- a/ol_schema/app/app.go
+++ b/ol_schema/app/app.go
@@ -116,11 +116,25 @@ func Inflate(s map[string]interface{}) (models.App, error) {
 
 	app := models.App{
 		Name:               &name,
-		Description:        &description,
-		Notes:              &notes,
 		ConnectorID:        &connectorID,
 		Visible:            &visible,
 		AllowAssumedSignin: &allowAssumedSignin,
+	}
+
+	// Left nil when empty rather than pointed at "". Both fields are tagged
+	// omitempty, but a pointer to an empty string is not empty -- only a nil
+	// pointer is -- so taking the address unconditionally sent `"notes": ""`
+	// for a field the API had returned as null, and the API stores what it is
+	// sent. An update touching only the description rewrote them.
+	//
+	// Omitting a field leaves it alone: the app endpoint takes a PUT but
+	// merges it, which is what makes leaving them out the right repair rather
+	// than reading the app first and echoing every field back.
+	if description != "" {
+		app.Description = &description
+	}
+	if notes != "" {
+		app.Notes = &notes
 	}
 
 	// Set optional fields

--- a/ol_schema/app/app_nulls_test.go
+++ b/ol_schema/app/app_nulls_test.go
@@ -33,10 +33,12 @@ func TestInflateDoesNotSendEmptyStringsForUnsetFields(t *testing.T) {
 	t.Run("omits notes and description when unset", func(t *testing.T) {
 		got := marshal(t, map[string]interface{}{"name": "test app"})
 
-		if strings.Contains(got, `"notes"`) {
+		// The field token rather than the bare name: a value containing the
+		// word "notes" would otherwise satisfy the check.
+		if strings.Contains(got, `"notes":`) {
 			t.Fatalf("expected notes to be omitted, got %s", got)
 		}
-		if strings.Contains(got, `"description"`) {
+		if strings.Contains(got, `"description":`) {
 			t.Fatalf("expected description to be omitted, got %s", got)
 		}
 	})
@@ -52,7 +54,7 @@ func TestInflateDoesNotSendEmptyStringsForUnsetFields(t *testing.T) {
 		if !strings.Contains(got, `"description":"a new description"`) {
 			t.Fatalf("expected the description to be sent, got %s", got)
 		}
-		if strings.Contains(got, `"notes"`) {
+		if strings.Contains(got, `"notes":`) {
 			t.Fatalf("expected notes to stay out of an unrelated update, got %s", got)
 		}
 	})

--- a/ol_schema/app/app_nulls_test.go
+++ b/ol_schema/app/app_nulls_test.go
@@ -1,0 +1,79 @@
+package appschema
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestInflateDoesNotSendEmptyStringsForUnsetFields covers issue #237.
+//
+// notes and description are *string tagged omitempty, but a pointer to "" is
+// not empty to encoding/json -- only a nil pointer is. Taking the address
+// unconditionally therefore sent `"notes": ""` for a field the API had returned
+// as null, and the API stores what it is sent, so an update touching only the
+// description rewrote unrelated fields.
+//
+// The assertion is on the marshalled body rather than the struct, because the
+// bug only exists once it is serialised.
+func TestInflateDoesNotSendEmptyStringsForUnsetFields(t *testing.T) {
+	marshal := func(t *testing.T, s map[string]interface{}) string {
+		t.Helper()
+		app, err := Inflate(s)
+		if err != nil {
+			t.Fatalf("inflate: %v", err)
+		}
+		b, err := json.Marshal(app)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		return string(b)
+	}
+
+	t.Run("omits notes and description when unset", func(t *testing.T) {
+		got := marshal(t, map[string]interface{}{"name": "test app"})
+
+		if strings.Contains(got, `"notes"`) {
+			t.Fatalf("expected notes to be omitted, got %s", got)
+		}
+		if strings.Contains(got, `"description"`) {
+			t.Fatalf("expected description to be omitted, got %s", got)
+		}
+	})
+
+	t.Run("omits notes while description is being changed", func(t *testing.T) {
+		// The exact shape reported in #237: an update that sets only the
+		// description must not carry notes along with it.
+		got := marshal(t, map[string]interface{}{
+			"name":        "test app",
+			"description": "a new description",
+		})
+
+		if !strings.Contains(got, `"description":"a new description"`) {
+			t.Fatalf("expected the description to be sent, got %s", got)
+		}
+		if strings.Contains(got, `"notes"`) {
+			t.Fatalf("expected notes to stay out of an unrelated update, got %s", got)
+		}
+	})
+
+	t.Run("still sends both when they are set", func(t *testing.T) {
+		got := marshal(t, map[string]interface{}{
+			"name":        "test app",
+			"description": "d",
+			"notes":       "n",
+		})
+
+		if !strings.Contains(got, `"description":"d"`) || !strings.Contains(got, `"notes":"n"`) {
+			t.Fatalf("expected both values to be sent, got %s", got)
+		}
+	})
+
+	t.Run("name is always sent", func(t *testing.T) {
+		// name is required and carries no omitempty; it is not part of the fix
+		// and must not be caught by it.
+		if got := marshal(t, map[string]interface{}{"name": "test app"}); !strings.Contains(got, `"name":"test app"`) {
+			t.Fatalf("expected name to be sent, got %s", got)
+		}
+	})
+}

--- a/ol_schema/app/parameters/parameter.go
+++ b/ol_schema/app/parameters/parameter.go
@@ -82,23 +82,33 @@ func Inflate(s map[string]interface{}) models.Parameter {
 		out.Label = st
 	}
 
-	if st, notNil = s["user_attribute_mappings"].(string); notNil {
+	// These are interface{} on the model, and an interface holding "" is not
+	// empty for encoding/json -- only a nil interface is. Assigning whatever
+	// Terraform reports therefore sent `"values": ""` for a parameter the API
+	// had returned as null, and the API stores what it is sent. An update
+	// touching only the app description rewrote all four.
+	//
+	// Leaving them nil omits them, and the app endpoint merges its PUT rather
+	// than replacing, so an untouched field keeps whatever it already had.
+	// default_values carries no omitempty and so goes out as an explicit null,
+	// which the API also treats as "no value" -- the state it was already in.
+	if st, notNil = s["user_attribute_mappings"].(string); notNil && st != "" {
 		out.UserAttributeMappings = st
 	}
 
-	if st, notNil = s["user_attribute_macros"].(string); notNil {
+	if st, notNil = s["user_attribute_macros"].(string); notNil && st != "" {
 		out.UserAttributeMacros = st
 	}
 
-	if st, notNil = s["attributes_transformations"].(string); notNil {
+	if st, notNil = s["attributes_transformations"].(string); notNil && st != "" {
 		out.AttributesTransformations = st
 	}
 
-	if st, notNil = s["values"].(string); notNil {
+	if st, notNil = s["values"].(string); notNil && st != "" {
 		out.Values = st
 	}
 
-	if st, notNil = s["default_values"].(string); notNil {
+	if st, notNil = s["default_values"].(string); notNil && st != "" {
 		out.DefaultValues = st
 	}
 

--- a/ol_schema/app/parameters/parameter_nulls_test.go
+++ b/ol_schema/app/parameters/parameter_nulls_test.go
@@ -1,0 +1,73 @@
+package appparametersschema
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestInflateDoesNotSendEmptyStringsForUnsetFields covers issue #237 for app
+// parameters.
+//
+// These fields are interface{} on the model. An interface holding "" is not
+// empty to encoding/json -- only a nil interface is -- so omitempty did not
+// protect them, and assigning whatever Terraform reported sent `"values": ""`
+// for parameters the API had returned as null.
+//
+// Asserted on the marshalled body, since that is where the defect lives: the
+// struct looks reasonable either way.
+func TestInflateDoesNotSendEmptyStringsForUnsetFields(t *testing.T) {
+	marshal := func(t *testing.T, s map[string]interface{}) string {
+		t.Helper()
+		b, err := json.Marshal(Inflate(s))
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		return string(b)
+	}
+
+	t.Run("omits the string fields when unset", func(t *testing.T) {
+		got := marshal(t, map[string]interface{}{"label": "Groups"})
+
+		for _, key := range []string{"values", "user_attribute_macros", "user_attribute_mappings", "attributes_transformations"} {
+			if strings.Contains(got, `"`+key+`":""`) {
+				t.Fatalf("expected %s to be omitted rather than sent as \"\", got %s", key, got)
+			}
+		}
+	})
+
+	t.Run("sends default_values as null rather than empty string", func(t *testing.T) {
+		// default_values carries no omitempty, so it is always serialised. A
+		// nil interface makes that an explicit null, which is the state the
+		// API was already in -- an empty string is a different value.
+		got := marshal(t, map[string]interface{}{"label": "Groups"})
+
+		if strings.Contains(got, `"default_values":""`) {
+			t.Fatalf("expected null rather than an empty string, got %s", got)
+		}
+		if !strings.Contains(got, `"default_values":null`) {
+			t.Fatalf("expected an explicit null, got %s", got)
+		}
+	})
+
+	t.Run("still sends values that are set", func(t *testing.T) {
+		got := marshal(t, map[string]interface{}{
+			"label":                 "Groups",
+			"values":                "memberOf",
+			"default_values":        "everyone",
+			"user_attribute_macros": "{$user.email}",
+		})
+
+		for _, want := range []string{`"values":"memberOf"`, `"default_values":"everyone"`, `"user_attribute_macros":"{$user.email}"`} {
+			if !strings.Contains(got, want) {
+				t.Fatalf("expected %s in %s", want, got)
+			}
+		}
+	})
+
+	t.Run("label survives, it is not one of the guarded fields", func(t *testing.T) {
+		if got := marshal(t, map[string]interface{}{"label": "Groups"}); !strings.Contains(got, `"label":"Groups"`) {
+			t.Fatalf("expected the label to be sent, got %s", got)
+		}
+	})
+}


### PR DESCRIPTION
Fixes #237

## The bug

Changing only an app's `description` also rewrote `notes`, and every parameter's `values`, `default_values`, `user_attribute_macros` and `attributes_transformations`, from `null` to `""`.

## Both halves are the same mistake about `omitempty`

`omitempty` does far less than it looks like it does here:

```go
type P struct {
    Values        interface{} `json:"values,omitempty"`
    DefaultValues interface{} `json:"default_values"`
}
type A struct{ Notes *string `json:"notes,omitempty"` }
```
```
interface{} holding "":   {"values":"","default_values":""}     <- omitempty did nothing
interface{} left nil:     {"default_values":null}
*string pointing at "":   {"notes":""}                          <- omitempty did nothing
*string nil:              {}
```

`encoding/json` treats an interface as empty only when it is **nil**, and a pointer only when it is **nil**. A pointer to `""` and an interface holding `""` are both non-empty, so both were serialised.

`Inflate` produced exactly those shapes: it took `&notes` unconditionally, and assigned the parameter interfaces whatever Terraform reported — which for an unset `TypeString` is `""`. `default_values` carries no `omitempty` at all, so it went out regardless.

## The fix

Leave them nil when empty.

That works because **the app endpoint merges its PUT rather than replacing** — verified against a development tenant. An omitted field keeps whatever it already had, which is what makes leaving fields out the right repair, rather than reading the app first and echoing every field back:

```
omitting a field preserves it : True
notes='' is stored as ''      : True     <- the corruption
notes=null clears it          : True
```

`default_values` still serialises, now as an explicit `null` — the state it was already in.

## Verified end to end

Both payloads run against a real app on a development tenant, created and deleted by the probe:

| payload | notes | default_values | |
| --- | --- | --- | --- |
| before the fix | `None` → `''` | `None` → `''` | corrupts |
| after the fix | `None` → `None` | `None` → `None` | preserves |

## Known limitation, stated deliberately

Terraform cannot distinguish "unset" from "explicitly empty" for a `TypeString`, so **setting one of these fields to `""` no longer clears it** — it is now omitted and the previous value survives. Clearing needs an explicit `null`, which Terraform cannot express here.

That is a real trade-off and I would rather it were visible than buried: silently corrupting fields the user never mentioned is worse than being unable to blank one deliberately. This is the same null-versus-empty problem as `position` (#224) and the `name` fix in v0.14.0 — the third instance in this codebase — and a general answer to it is worth its own discussion.

## Testing

- `make test`, `go build`, `go vet`, `gofmt` all clean.
- New unit tests assert on the **marshalled JSON** rather than the struct, since the defect only exists once serialised. They cover: omitted when unset, omitted while an unrelated field changes, still sent when set, `default_values` as `null` rather than `""`, and that `name` — required, no `omitempty` — is not caught by the change.
- The live before/after comparison above.