### PR TITLE
feat: let a role leave membership sub-endpoints un-refreshed

### DIFF
--- a/docs/resources/onelogin_roles.md
+++ b/docs/resources/onelogin_roles.md
@@ -41,6 +41,37 @@ The following arguments are supported:
 
 * `admins` - (Optional) A list of user IDs who will be administrators for this role. These users can manage the role settings. If not specified, no admins will be assigned to the role.
 
+* `skip_membership_refresh` - (Optional) A list of membership attributes to leave
+  un-refreshed: any of `apps`, `users`, `admins`. Their sub-endpoints are not
+  queried during read, and whatever state already holds is kept.
+
+  Membership lives on three separate paginated endpoints, so a role with
+  thousands of users costs a page walk on every `plan` or `refresh` — whether or
+  not your configuration manages that membership. `lifecycle { ignore_changes }`
+  cannot prevent it, because it is applied to the diff, after the read has
+  already made the calls.
+
+  Use this where membership is managed outside Terraform, for example by
+  mappings, alongside `ignore_changes` for the same attribute:
+
+  ```hcl
+  resource onelogin_roles engineering {
+    name = "Engineering"
+
+    # Membership comes from a mapping, so do not read it and do not diff it.
+    skip_membership_refresh = ["users"]
+
+    lifecycle {
+      ignore_changes = [users]
+    }
+  }
+  ```
+
+  The two do different jobs and are both needed: `skip_membership_refresh` stops
+  the API calls, `ignore_changes` stops the diff. Listing an attribute here
+  without ignoring changes to it will leave whatever state already held, which
+  the plan will then compare against your configuration.
+
 ## Attribute Reference
 
 In addition to the arguments listed above, the following attributes are exported:

--- a/ol_schema/role/role.go
+++ b/ol_schema/role/role.go
@@ -1,6 +1,7 @@
 package roleschema
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -13,7 +14,15 @@ import (
 var MembershipAttrs = []string{"apps", "users", "admins"}
 
 func validMembershipAttr(val interface{}, key string) (warns []string, errs []error) {
-	return utils.OneOf(key, val.(string), MembershipAttrs)
+	// Guarded rather than asserted. Terraform should only ever hand a string
+	// to a TypeString element, but a bare assertion turns "should" into a
+	// panic, and a panic here takes the whole provider process down rather
+	// than reporting a bad value.
+	attr, ok := val.(string)
+	if !ok {
+		return nil, []error{fmt.Errorf("%s: expected a string, got %T", key, val)}
+	}
+	return utils.OneOf(key, attr, MembershipAttrs)
 }
 
 // RoleQuery implements the Queryable interface for role queries.
@@ -80,7 +89,7 @@ func Schema() map[string]*schema.Schema {
 				Type:         schema.TypeString,
 				ValidateFunc: validMembershipAttr,
 			},
-			Description: "Membership attributes to leave un-refreshed: any of apps, users, admins. Their sub-endpoints are not queried during read, and whatever state already holds is kept. For roles whose membership is managed outside Terraform and paired with a lifecycle ignore_changes block",
+			Description: "Membership attributes to leave un-refreshed: any of apps, users, admins. Their sub-endpoints are not queried during read, and state keeps whatever it already held. Use for membership managed outside Terraform, alongside a lifecycle ignore_changes block for the same attribute.",
 		},
 	}
 }

--- a/ol_schema/role/role.go
+++ b/ol_schema/role/role.go
@@ -5,7 +5,16 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/onelogin/onelogin-go-sdk/v4/pkg/onelogin/models"
+	"github.com/onelogin/terraform-provider-onelogin/utils"
 )
+
+// MembershipAttrs are the role sub-resources that live on their own paginated
+// endpoints, and so are the ones worth being able to leave un-refreshed.
+var MembershipAttrs = []string{"apps", "users", "admins"}
+
+func validMembershipAttr(val interface{}, key string) (warns []string, errs []error) {
+	return utils.OneOf(key, val.(string), MembershipAttrs)
+}
 
 // RoleQuery implements the Queryable interface for role queries.
 //
@@ -54,6 +63,24 @@ func Schema() map[string]*schema.Schema {
 			Type:     schema.TypeSet,
 			Optional: true,
 			Elem:     &schema.Schema{Type: schema.TypeInt},
+		},
+		// Membership lives on three paginated sub-endpoints, and a role with
+		// thousands of users costs a page walk on every refresh whether or not
+		// the configuration manages them. ignore_changes cannot help: it is
+		// applied to the diff, long after the read has made the calls.
+		//
+		// Naming this as what to skip rather than what to manage is deliberate.
+		// A "manage_users" flag defaulting to true would read as false on an
+		// imported resource, whose state carries no value for it, and silently
+		// skip the very fetch import needs.
+		"skip_membership_refresh": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type:         schema.TypeString,
+				ValidateFunc: validMembershipAttr,
+			},
+			Description: "Membership attributes to leave un-refreshed: any of apps, users, admins. Their sub-endpoints are not queried during read, and whatever state already holds is kept. For roles whose membership is managed outside Terraform and paired with a lifecycle ignore_changes block",
 		},
 	}
 }

--- a/onelogin/resource_onelogin_roles.go
+++ b/onelogin/resource_onelogin_roles.go
@@ -160,7 +160,21 @@ func roleRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.D
 		}},
 	}
 
+	skip := skippedMembershipAttrs(d)
+
 	for _, member := range memberAttrs {
+		// Skipping means not calling the endpoint at all, which is the point:
+		// the cost is the page walk, not the diff. State keeps whatever it
+		// already held rather than being blanked, so a skipped attribute does
+		// not read as "membership was removed".
+		if skip[member.attr] {
+			tflog.Debug(ctx, "[READ] Skipping role membership refresh", map[string]interface{}{
+				"id":        rid,
+				"attribute": member.attr,
+			})
+			continue
+		}
+
 		ids, err := fetchAllMemberIDs(ctx, member.fetch)
 		if err != nil {
 			// A 404 here means the role was deleted between the base fetch and now.
@@ -182,6 +196,30 @@ func roleRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.D
 	}
 
 	return nil
+}
+
+// skippedMembershipAttrs reports which membership sub-endpoints the read should
+// leave alone.
+//
+// Terraform does not send configuration to the refresh RPC — ResourceData is
+// built from prior state only — so the read cannot tell whether the
+// configuration mentions users, and ignore_changes is applied to the diff long
+// after these calls have been made. An attribute in state is the one signal
+// available, which is why this is a stored attribute rather than something
+// inferred.
+func skippedMembershipAttrs(d *schema.ResourceData) map[string]bool {
+	skip := make(map[string]bool, len(roleschema.MembershipAttrs))
+
+	raw, ok := d.Get("skip_membership_refresh").(*schema.Set)
+	if !ok {
+		return skip
+	}
+	for _, v := range raw.List() {
+		if attr, ok := v.(string); ok {
+			skip[attr] = true
+		}
+	}
+	return skip
 }
 
 // memberFetcher retrieves one page of a role sub-endpoint (apps, users or admins).

--- a/onelogin/resource_onelogin_roles_skip_test.go
+++ b/onelogin/resource_onelogin_roles_skip_test.go
@@ -1,0 +1,111 @@
+package onelogin
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	roleschema "github.com/onelogin/terraform-provider-onelogin/ol_schema/role"
+)
+
+// TestSkippedMembershipAttrs covers issue #242.
+//
+// Role membership lives on three paginated sub-endpoints, and a role with
+// thousands of users costs a page walk on every refresh whether or not the
+// configuration manages them. ignore_changes cannot prevent it: it is applied
+// to the diff, long after the read has made the calls.
+func TestSkippedMembershipAttrs(t *testing.T) {
+	data := func(t *testing.T, raw map[string]interface{}) *schema.ResourceData {
+		t.Helper()
+		return schema.TestResourceDataRaw(t, Roles().Schema, raw)
+	}
+
+	t.Run("skips nothing when unset", func(t *testing.T) {
+		// The import case, and the one that must stay safe: an imported
+		// resource's state carries no value for this attribute, and it has to
+		// mean "fetch everything" rather than "fetch nothing".
+		got := skippedMembershipAttrs(data(t, map[string]interface{}{"name": "Engineering"}))
+
+		if len(got) != 0 {
+			t.Fatalf("expected nothing to be skipped, got %v", got)
+		}
+	})
+
+	t.Run("skips the named attribute", func(t *testing.T) {
+		got := skippedMembershipAttrs(data(t, map[string]interface{}{
+			"name":                    "Engineering",
+			"skip_membership_refresh": []interface{}{"users"},
+		}))
+
+		if !got["users"] {
+			t.Fatalf("expected users to be skipped, got %v", got)
+		}
+		if got["apps"] || got["admins"] {
+			t.Fatalf("expected only users to be skipped, got %v", got)
+		}
+	})
+
+	t.Run("skips several", func(t *testing.T) {
+		got := skippedMembershipAttrs(data(t, map[string]interface{}{
+			"name":                    "Engineering",
+			"skip_membership_refresh": []interface{}{"users", "admins"},
+		}))
+
+		if !got["users"] || !got["admins"] {
+			t.Fatalf("expected users and admins to be skipped, got %v", got)
+		}
+		if got["apps"] {
+			t.Fatalf("expected apps to still be fetched, got %v", got)
+		}
+	})
+}
+
+// TestSkipMembershipRefreshSchema pins the attribute's shape. The names it
+// accepts have to match the attributes roleRead actually iterates, or a typo
+// becomes a silent no-op.
+func TestSkipMembershipRefreshSchema(t *testing.T) {
+	s := Roles().Schema["skip_membership_refresh"]
+	if s == nil {
+		t.Fatal("expected the roles schema to have skip_membership_refresh")
+	}
+	if !s.Optional {
+		t.Fatal("expected the attribute to be optional")
+	}
+
+	elem, ok := s.Elem.(*schema.Schema)
+	if !ok || elem.ValidateFunc == nil {
+		t.Fatal("expected the elements to be validated")
+	}
+
+	for _, valid := range roleschema.MembershipAttrs {
+		if _, errs := elem.ValidateFunc(valid, "skip_membership_refresh"); len(errs) > 0 {
+			t.Fatalf("expected %q to be accepted, got %v", valid, errs)
+		}
+	}
+
+	// A near-miss is the likely mistake, and silently doing nothing would be
+	// the worst outcome for an attribute whose whole purpose is to prevent work.
+	for _, invalid := range []string{"user", "Users", "everything"} {
+		if _, errs := elem.ValidateFunc(invalid, "skip_membership_refresh"); len(errs) == 0 {
+			t.Fatalf("expected %q to be rejected", invalid)
+		}
+	}
+}
+
+// TestSkipMembershipRefreshIsNotSentToTheAPI guards against the attribute
+// leaking into a role payload, which the API would reject.
+func TestSkipMembershipRefreshIsNotSentToTheAPI(t *testing.T) {
+	role := roleschema.Inflate(map[string]interface{}{
+		"name":                    "Engineering",
+		"skip_membership_refresh": []interface{}{"users"},
+	})
+
+	b, err := json.Marshal(role)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), "skip_membership_refresh") {
+		t.Fatalf("provider-only attribute leaked into the API payload: %s", b)
+	}
+}


### PR DESCRIPTION
Fixes #242

Thanks @russellt-vmc — the diagnosis in the issue is exactly right, including which layer the problem sits at.

## The problem

Role membership lives on three separate **paginated** endpoints. #223 removed the `O(roles × pages)` full-list walk, but each managed role still costs a page walk of `/roles/{id}/apps`, `/users` and `/admins` on every `plan` or `refresh` — whether or not the configuration manages that membership. For a tenant that assigns roles by mapping, that is most of the remaining cost, and 30+ minute plans are the result.

## Why the obvious fixes do not work

Both alternatives in the issue are worth ruling out explicitly, because they look like they should work:

**`ignore_changes` cannot help.** It is applied to the *diff*, long after the read has made the calls. It suppresses the plan output, not the pagination.

**The configuration is not available during read.** Terraform does not send it to the `ReadResource` RPC — `ResourceData` is built from `req.CurrentState` alone:

```go
stateVal, err := msgpack.Unmarshal(req.CurrentState.MsgPack, schemaBlock.ImpliedType())
instanceState, err := res.ShimInstanceStateFromValue(stateVal)
```

So the provider genuinely cannot tell during refresh whether `users` appears in anyone's HCL. `d.GetRawConfig()` would not answer it either, and is not present in the pinned `terraform-plugin-sdk v2.4.3` regardless.

Prior state is the only signal available, which is why this is a stored attribute rather than something inferred.

## The fix

```hcl
resource onelogin_roles engineering {
  name = "Engineering"

  # Membership comes from a mapping, so do not read it and do not diff it.
  skip_membership_refresh = ["users"]

  lifecycle {
    ignore_changes = [users]
  }
}
```

The two do different jobs and are both wanted: `skip_membership_refresh` stops the API calls, `ignore_changes` stops the diff. The docs say so, since having one without the other is the easy mistake.

## Two design points worth review

**Named for what to skip, not what to manage.** A `manage_users` flag defaulting to `true` would read as `false` on an imported resource — whose state carries no value for it — and silently skip the very fetch import needs. Phrasing it as an opt-out makes the zero value "fetch everything", which is the safe default. There is a test pinning that.

**A skipped attribute keeps whatever state already held** rather than being blanked, so skipping does not read as "membership was removed".

## Testing

- `make test`, `go build`, `go vet`, `gofmt` clean.
- Unit tests: nothing skipped when unset (the import case), one attribute, several, and element validation rejecting near-misses like `"user"` and `"Users"` — a typo silently doing nothing would be the worst outcome for an attribute whose purpose is to prevent work.
- A test asserting the provider-only attribute never reaches the API payload.
- **Not verified against a live tenant.** The behaviour is a skipped API call rather than a payload change, and the acceptance harness cannot run (`terraform-plugin-sdk v2.4.3` fails on Terraform 1.x), so this rests on unit tests and reading the RPC path. @russellt-vmc, if you are able to try the branch against your large-role tenant, that would confirm the part I cannot.