### PR TITLE
revert: keep sso configurable until the next major

### DIFF
--- a/onelogin/resource_onelogin_saml_apps.go
+++ b/onelogin/resource_onelogin_saml_apps.go
@@ -27,14 +27,17 @@ func SAMLApps() *schema.Resource {
 		Optional: true,
 		Elem:     &schema.Schema{Type: schema.TypeString},
 	}
-	// Computed rather than Optional. OneLogin documents every sso attribute as
-	// read-only, and appschema.Inflate has never sent this field, so a
-	// practitioner configuring it was writing something the provider silently
-	// discarded. Accepting configuration the API cannot be told about is worse
-	// than refusing it.
+	// Should be Computed: OneLogin documents every sso attribute as read-only,
+	// and appschema.Inflate has never sent this field, so configuring it writes
+	// something the provider silently discards. See #236.
+	//
+	// Left Optional for now because making it Computed rejects any
+	// configuration that sets it, which fails a plan that previously
+	// succeeded. That is held back for the next major release, so it lands
+	// alongside the other breaking change rather than arriving on its own.
 	appSchema["sso"] = &schema.Schema{
 		Type:     schema.TypeMap,
-		Computed: true,
+		Optional: true,
 		Elem:     &schema.Schema{Type: schema.TypeString},
 	}
 	return &schema.Resource{

--- a/onelogin/resource_onelogin_saml_apps.go
+++ b/onelogin/resource_onelogin_saml_apps.go
@@ -27,17 +27,29 @@ func SAMLApps() *schema.Resource {
 		Optional: true,
 		Elem:     &schema.Schema{Type: schema.TypeString},
 	}
-	// Should be Computed: OneLogin documents every sso attribute as read-only,
-	// and appschema.Inflate has never sent this field, so configuring it writes
-	// something the provider silently discards. See #236.
+	// Optional *and* Computed, which are three different schemas and only one
+	// of them breaks anyone:
 	//
-	// Left Optional for now because making it Computed rejects any
-	// configuration that sets it, which fails a plan that previously
-	// succeeded. That is held back for the next major release, so it lands
-	// alongside the other breaking change rather than arriving on its own.
+	//   Optional only          — samlAppRead populates sso from the API, so a
+	//                            configuration that omits it has an empty value
+	//                            against populated state: a diff on every plan.
+	//   Optional and Computed  — configuration is still accepted, and an
+	//                            omitted attribute keeps whatever the API
+	//                            returned instead of planning its removal.
+	//   Computed only          — configuration that sets sso is rejected, so a
+	//                            plan that used to succeed now fails.
+	//
+	// The last is what #236 actually asks for: OneLogin documents every sso
+	// attribute as read-only and appschema.Inflate has never sent the field, so
+	// configuring it writes something the provider discards. It is breaking, so
+	// it waits for the next major.
+	//
+	// This is the middle one. It fixes the perpetual diff now, without
+	// rejecting anybody's configuration.
 	appSchema["sso"] = &schema.Schema{
 		Type:     schema.TypeMap,
 		Optional: true,
+		Computed: true,
 		Elem:     &schema.Schema{Type: schema.TypeString},
 	}
 	return &schema.Resource{

--- a/onelogin/resource_onelogin_saml_apps_sso_test.go
+++ b/onelogin/resource_onelogin_saml_apps_sso_test.go
@@ -2,28 +2,42 @@ package onelogin
 
 import "testing"
 
-// TestSamlAppSSOStaysConfigurableUntilTheNextMajor pins the deferral of #236.
+// TestSamlAppSSOStaysConfigurable pins sso as Optional until a major release.
 //
-// sso should be Computed: OneLogin documents every app sso attribute as
-// read-only, and appschema.Inflate has never sent the field, so configuring it
-// writes something the provider silently discards.
+// The distinction that matters is Computed-only, not Computed. Three schemas
+// are possible and only one of them breaks anyone:
 //
-// Making it Computed rejects any configuration that sets it, which fails a plan
-// that previously succeeded. It is held for the next major so it arrives
-// alongside the other breaking change rather than on its own, and this test
-// exists so the deferral is deliberate rather than forgotten.
+//	Optional only          samlAppRead populates sso from the API, so a
+//	                       configuration that omits it has an empty value
+//	                       against populated state: a diff on every plan.
+//	Optional and Computed  configuration is still accepted, and an omitted
+//	                       attribute keeps what the API returned.
+//	Computed only          configuration that sets sso is rejected, so a plan
+//	                       that used to succeed now fails.
 //
-// When that major comes: invert this test, and re-close #236.
-func TestSamlAppSSOStaysConfigurableUntilTheNextMajor(t *testing.T) {
+// #236 asks for the last, because sso is read-only at the API and
+// appschema.Inflate has never sent it. That is breaking and waits for the next
+// major. Until then Optional must hold, so this test guards the one property
+// that would break a practitioner — not Computed, which is wanted.
+//
+// When the major comes: drop Optional, set Computed only, invert this test,
+// and re-close #236.
+func TestSamlAppSSOStaysConfigurable(t *testing.T) {
 	sso := SAMLApps().Schema["sso"]
 
 	if sso == nil {
 		t.Fatal("expected the saml app schema to have an sso attribute")
 	}
+
+	// The whole guarantee. Optional false with Computed true is the breaking
+	// shape; Computed on its own is not.
 	if !sso.Optional {
-		t.Fatal("expected sso to still be Optional; making it Computed is a breaking change held for the next major (#236)")
+		t.Fatal("sso stopped being Optional, which rejects any configuration that sets it — that belongs in a major release (#236)")
 	}
-	if sso.Computed {
-		t.Fatal("sso became Computed, which fails any plan that configures it — that belongs in a major release (#236)")
+
+	// Not a breaking change, and wanted: without it, a configuration that omits
+	// sso diffs against the value samlAppRead writes into state.
+	if !sso.Computed {
+		t.Fatal("expected sso to be Computed alongside Optional, so omitting it does not diff against what read populates")
 	}
 }

--- a/onelogin/resource_onelogin_saml_apps_sso_test.go
+++ b/onelogin/resource_onelogin_saml_apps_sso_test.go
@@ -2,22 +2,28 @@ package onelogin
 
 import "testing"
 
-// TestSamlAppSSOIsReadOnly covers issue #236.
+// TestSamlAppSSOStaysConfigurableUntilTheNextMajor pins the deferral of #236.
 //
-// OneLogin documents every app sso attribute as read-only, and
-// appschema.Inflate has never sent the field. Leaving it Optional meant
-// Terraform accepted configuration the provider then silently discarded --
-// config that looks effective and does nothing.
-func TestSamlAppSSOIsReadOnly(t *testing.T) {
+// sso should be Computed: OneLogin documents every app sso attribute as
+// read-only, and appschema.Inflate has never sent the field, so configuring it
+// writes something the provider silently discards.
+//
+// Making it Computed rejects any configuration that sets it, which fails a plan
+// that previously succeeded. It is held for the next major so it arrives
+// alongside the other breaking change rather than on its own, and this test
+// exists so the deferral is deliberate rather than forgotten.
+//
+// When that major comes: invert this test, and re-close #236.
+func TestSamlAppSSOStaysConfigurableUntilTheNextMajor(t *testing.T) {
 	sso := SAMLApps().Schema["sso"]
 
 	if sso == nil {
 		t.Fatal("expected the saml app schema to have an sso attribute")
 	}
-	if sso.Optional {
-		t.Fatal("expected sso to be read-only, the API does not accept it and Inflate never sent it")
+	if !sso.Optional {
+		t.Fatal("expected sso to still be Optional; making it Computed is a breaking change held for the next major (#236)")
 	}
-	if !sso.Computed {
-		t.Fatal("expected sso to be Computed so it is still populated on read and import")
+	if sso.Computed {
+		t.Fatal("sso became Computed, which fails any plan that configures it — that belongs in a major release (#236)")
 	}
 }


### PR DESCRIPTION
Reopens #236, deliberately.

## Why

Making `sso` Computed is right — OneLogin documents every app `sso` attribute as read-only, and `appschema.Inflate` has never sent the field, so configuring it writes something the provider discards. But Terraform rejects any configuration that sets a Computed-only attribute, so it **fails a plan that previously succeeded**. That is a breaking change.

It is currently the *only* breaking change merged since v0.14.0. Everything else is safe in a minor:

| change | breaking? |
| --- | --- |
| #237 — nulls no longer rewritten as empty strings | no. Changes what apply does and wants a release note, but no plan fails |
| #235 — `safe_entitlements_enabled` now actually sent | no. A previously-inert config becomes effective; a fix, but worth noting |
| `post_logout_redirect_uri`, `include_amr_claims` | no — **new attributes**, so no existing configuration can contain them |
| dependency bumps, docs, CI | no user impact |

Worth stating plainly: the "non-boolean `include_amr_claims` is now an error" note from #244 **cannot affect anyone**. The attribute does not exist in any released version, so no config can have it. I over-flagged that.

## What this buys

Holding this one commit lets v0.15.0 ship the field-corruption fix and the roles refresh fix now, and keeps every break in a single deliberate major — landing `sso` alongside the parameter type change #239 needs, rather than spending a major on each.

The alternative is holding all of it until that major, which leaves users hitting silent field corruption and 30-minute plans in the meantime.

## The test is inverted, not deleted

`TestSamlAppSSOStaysConfigurableUntilTheNextMajor` now asserts `sso` is still Optional, and says in its own comment what to do when the major arrives: invert it again and re-close #236. A deleted test would make this a thing someone has to remember; an inverted one makes it a thing the suite tells them.

## Verified

- No `Optional`/`Computed`/`Required` changes remain anywhere between v0.14.0 and this branch.
- `sso` differs from v0.14.0 only by comments.
- `make test`, `go build`, `go vet`, `gofmt` clean.