### PR TITLE
fix: stop a validator panicking on a value that is not a string

### DIFF
--- a/ol_schema/role/role.go
+++ b/ol_schema/role/role.go
@@ -1,7 +1,6 @@
 package roleschema
 
 import (
-	"fmt"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -14,15 +13,7 @@ import (
 var MembershipAttrs = []string{"apps", "users", "admins"}
 
 func validMembershipAttr(val interface{}, key string) (warns []string, errs []error) {
-	// Guarded rather than asserted. Terraform should only ever hand a string
-	// to a TypeString element, but a bare assertion turns "should" into a
-	// panic, and a panic here takes the whole provider process down rather
-	// than reporting a bad value.
-	attr, ok := val.(string)
-	if !ok {
-		return nil, []error{fmt.Errorf("%s: expected a string, got %T", key, val)}
-	}
-	return utils.OneOf(key, attr, MembershipAttrs)
+	return utils.OneOfValue(key, val, MembershipAttrs)
 }
 
 // RoleQuery implements the Queryable interface for role queries.

--- a/ol_schema/rules/rules.go
+++ b/ol_schema/rules/rules.go
@@ -54,7 +54,7 @@ func Schema() map[string]*schema.Schema {
 }
 
 func validMatch(val interface{}, key string) (warns []string, errs []error) {
-	return utils.OneOf(key, val.(string), []string{"all", "any"})
+	return utils.OneOfValue(key, val, []string{"all", "any"})
 }
 
 // Inflate takes a key/value map of interfaces and uses the fields to construct

--- a/ol_schema/smarthook/smarthook.go
+++ b/ol_schema/smarthook/smarthook.go
@@ -84,7 +84,7 @@ func Schema() map[string]*schema.Schema {
 }
 
 func validTypes(val interface{}, key string) (warns []string, errs []error) {
-	return utils.OneOf(key, val.(string), []string{"pre-authentication", "user-migration"})
+	return utils.OneOfValue(key, val, []string{"pre-authentication", "user-migration"})
 }
 
 // Inflate takes a key/value map of interfaces and uses the fields to construct

--- a/ol_schema/user_mapping/user_mapping.go
+++ b/ol_schema/user_mapping/user_mapping.go
@@ -50,7 +50,7 @@ func Schema() map[string]*schema.Schema {
 }
 
 func validMatch(val interface{}, key string) (warns []string, errs []error) {
-	return utils.OneOf(key, val.(string), []string{"all", "any"})
+	return utils.OneOfValue(key, val, []string{"all", "any"})
 }
 
 // Inflate takes a key/value map of interfaces and uses the fields to construct a user mapping struct

--- a/onelogin/provider_validators_test.go
+++ b/onelogin/provider_validators_test.go
@@ -14,9 +14,14 @@ import (
 // somebody's pipeline. Walking the live schema means this covers validators
 // that do not exist yet.
 func TestValidatorsDoNotPanicOnUnexpectedTypes(t *testing.T) {
-	// Deliberately includes a value of the type each validator expects to
-	// reject as well as types it could never receive.
-	unexpected := []interface{}{nil, 42, true, 3.14, []string{"x"}, map[string]string{}, struct{}{}}
+	// Types a validator should never receive, plus a string that is simply not
+	// an allowed value. The string exercises the ordinary rejection path: a
+	// guard that returned early on every input would satisfy the rest of this
+	// list while breaking validation entirely.
+	unexpected := []interface{}{
+		nil, 42, true, 3.14, []string{"x"}, map[string]string{}, struct{}{},
+		"definitely-not-an-allowed-value",
+	}
 
 	var walk func(t *testing.T, path string, s map[string]*schema.Schema)
 	walk = func(t *testing.T, path string, s map[string]*schema.Schema) {
@@ -59,6 +64,12 @@ func TestValidatorsDoNotPanicOnUnexpectedTypes(t *testing.T) {
 	if len(p.ResourcesMap) == 0 {
 		t.Fatal("expected the provider to expose resources")
 	}
+
+	// The provider configuration block too, not only resources and data
+	// sources. Its attributes take a ValidateFunc like any others, and a panic
+	// there is worse than most: it happens before anything can be configured.
+	walk(t, "provider.", p.Schema)
+
 	for name, res := range p.ResourcesMap {
 		walk(t, name+".", res.Schema)
 	}

--- a/onelogin/provider_validators_test.go
+++ b/onelogin/provider_validators_test.go
@@ -1,0 +1,68 @@
+package onelogin
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// TestValidatorsDoNotPanicOnUnexpectedTypes walks every ValidateFunc the
+// provider actually wires up and hands each one values it should never see.
+//
+// The guard belongs in the validators, but the risk is that a new one is added
+// later with a bare assertion and nobody notices until a provider crashes in
+// somebody's pipeline. Walking the live schema means this covers validators
+// that do not exist yet.
+func TestValidatorsDoNotPanicOnUnexpectedTypes(t *testing.T) {
+	// Deliberately includes a value of the type each validator expects to
+	// reject as well as types it could never receive.
+	unexpected := []interface{}{nil, 42, true, 3.14, []string{"x"}, map[string]string{}, struct{}{}}
+
+	var walk func(t *testing.T, path string, s map[string]*schema.Schema)
+	walk = func(t *testing.T, path string, s map[string]*schema.Schema) {
+		for name, attr := range s {
+			key := path + name
+
+			if attr.ValidateFunc != nil {
+				for _, val := range unexpected {
+					func() {
+						defer func() {
+							if r := recover(); r != nil {
+								t.Errorf("%s panicked on %#v: %v — a validator must report a bad value, not take the provider down", key, val, r)
+							}
+						}()
+						attr.ValidateFunc(val, key)
+					}()
+				}
+			}
+
+			// Nested resources carry their own validators.
+			if res, ok := attr.Elem.(*schema.Resource); ok {
+				walk(t, key+".", res.Schema)
+			}
+			if elem, ok := attr.Elem.(*schema.Schema); ok && elem.ValidateFunc != nil {
+				for _, val := range unexpected {
+					func() {
+						defer func() {
+							if r := recover(); r != nil {
+								t.Errorf("%s element validator panicked on %#v: %v", key, val, r)
+							}
+						}()
+						elem.ValidateFunc(val, key)
+					}()
+				}
+			}
+		}
+	}
+
+	p := Provider()
+	if len(p.ResourcesMap) == 0 {
+		t.Fatal("expected the provider to expose resources")
+	}
+	for name, res := range p.ResourcesMap {
+		walk(t, name+".", res.Schema)
+	}
+	for name, ds := range p.DataSourcesMap {
+		walk(t, name+".", ds.Schema)
+	}
+}

--- a/utils/one_of_value_test.go
+++ b/utils/one_of_value_test.go
@@ -1,0 +1,69 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestOneOfValue covers the guard that keeps a validator from panicking.
+//
+// Terraform should only ever hand a string to a TypeString attribute, so the
+// assertion "cannot" fail. But a panic inside a validator takes the whole
+// provider process down and reports a stack trace rather than the offending
+// value, which is a poor trade against one type check.
+func TestOneOfValue(t *testing.T) {
+	opts := []string{"all", "any"}
+
+	t.Run("accepts an allowed value", func(t *testing.T) {
+		if _, errs := OneOfValue("match", "all", opts); len(errs) > 0 {
+			t.Fatalf("expected %q to be accepted, got %v", "all", errs)
+		}
+	})
+
+	t.Run("rejects a disallowed value", func(t *testing.T) {
+		_, errs := OneOfValue("match", "sometimes", opts)
+
+		if len(errs) == 0 {
+			t.Fatal("expected a disallowed value to be rejected")
+		}
+		if !strings.Contains(errs[0].Error(), "sometimes") {
+			t.Fatalf("expected the offending value in the error, got %v", errs[0])
+		}
+	})
+
+	t.Run("reports a non-string rather than panicking", func(t *testing.T) {
+		// The whole point. Each of these would have panicked on a bare
+		// assertion, taking the provider down with it.
+		for _, val := range []interface{}{42, true, nil, []string{"all"}, map[string]string{}} {
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						t.Fatalf("panicked on %#v: %v", val, r)
+					}
+				}()
+
+				_, errs := OneOfValue("match", val, opts)
+				if len(errs) == 0 {
+					t.Fatalf("expected %#v to be reported as an error", val)
+				}
+				if !strings.Contains(errs[0].Error(), "expected a string") {
+					t.Fatalf("expected a type error for %#v, got %v", val, errs[0])
+				}
+			}()
+		}
+	})
+
+	t.Run("names the key and the type it got", func(t *testing.T) {
+		// A validator error is all the practitioner sees, so it has to say
+		// which attribute and what arrived.
+		_, errs := OneOfValue("match", 42, opts)
+
+		if len(errs) == 0 {
+			t.Fatal("expected an error")
+		}
+		msg := errs[0].Error()
+		if !strings.Contains(msg, "match") || !strings.Contains(msg, "int") {
+			t.Fatalf("expected the key and the type in %q", msg)
+		}
+	})
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -21,6 +21,22 @@ func OneOf(key string, v string, opts []string) (warns []string, errs []error) {
 	return
 }
 
+// OneOfValue is OneOf for a value arriving from a schema.SchemaValidateFunc,
+// where it is an interface{} and asserting the string bare would panic.
+//
+// Terraform should only ever hand a string to a TypeString attribute, so the
+// assertion "cannot" fail. But a panic inside a validator takes the whole
+// provider process down and reports a stack trace rather than the bad value,
+// which is a poor trade against one type check. Corrupted state and schema
+// changes are the realistic routes in.
+func OneOfValue(key string, val interface{}, opts []string) (warns []string, errs []error) {
+	v, ok := val.(string)
+	if !ok {
+		return nil, []error{fmt.Errorf("%s: expected a string, got %T", key, val)}
+	}
+	return OneOf(key, v, opts)
+}
+
 func ParseNestedResourceImportId(id string) (string, string, error) {
 	parts := strings.SplitN(id, ":", 2)
 


### PR DESCRIPTION
Follows the finding Copilot raised on #245, where I had copied the bare assertion from its neighbours without questioning it.

## The problem

Three wired validators asserted `val.(string)` with no guard:

| validator | file |
| --- | --- |
| `validMatch` | `ol_schema/rules/rules.go` |
| `validMatch` | `ol_schema/user_mapping/user_mapping.go` |
| `validTypes` | `ol_schema/smarthook/smarthook.go` |

Terraform should only ever hand a string to a `TypeString` attribute, so the assertion "cannot" fail. But **a panic inside a validator takes the whole provider process down** and reports a stack trace rather than the offending value — a poor trade against one type check. Corrupted state and schema changes are the realistic routes in.

## Two corrections to the original scope

I said four validators; it is three, and one of them was already fine:

- **`validSignatureAlgorithm` is wired to no schema.** It is defined in `app/configuration` and referenced nowhere. Guarding it would polish something that never runs, so it is left alone — it is worth deleting, separately.
- **`validCustomAttributePosition` was already guarded** (`val.(int); ok &&`). So the codebase already held both patterns; I copied the wrong one on #245.

## The guard is shared, not copied

It lives in `utils.OneOfValue` beside `OneOf`, rather than being pasted into three files:

```go
func OneOfValue(key string, val interface{}, opts []string) (warns []string, errs []error) {
	v, ok := val.(string)
	if !ok {
		return nil, []error{fmt.Errorf("%s: expected a string, got %T", key, val)}
	}
	return OneOf(key, v, opts)
}
```

That way a validator written later gets the guard by using the helper its neighbours already use, instead of by remembering. `role.go`'s `validMembershipAttr` had its own copy from #245 and now uses it too.

## The test walks the schema rather than naming files

`TestValidatorsDoNotPanicOnUnexpectedTypes` iterates every resource and data source in the provider, finds every `ValidateFunc` — including element validators on nested resources — and feeds each one `nil`, an int, a bool, a float, a slice, a map and a struct.

**It therefore covers validators that do not exist yet**, which is the actual risk: not these three, but the fourth one somebody adds next year.

I checked it fails for the right reason rather than trusting it — reverting one guard produces:

```
--- FAIL: TestValidatorsDoNotPanicOnUnexpectedTypes
    onelogin_app_rules.match panicked on <nil>: interface conversion: interface {} is nil, not string
    onelogin_app_rules.match panicked on 42: interface conversion: interface {} is int, not string
```

It names the attribute, so a future failure points straight at the culprit.

## Testing

- `make test`, `go build`, `go vet`, `gofmt` clean.
- Unit tests on `OneOfValue`: allowed value, disallowed value, each unexpected type reported rather than panicking, and the error naming both the key and the type received — a validator error is all the practitioner sees.
- The schema walker above, verified to fail when a guard is removed.

No behaviour change for any valid configuration: a string that is allowed still passes, a string that is not still fails with the same message.