### PR TITLE
fix: stop onelogin_users panicking, and give fixtures unique names

### DIFF
--- a/examples/onelogin_privilege_example.tf
+++ b/examples/onelogin_privilege_example.tf
@@ -1,26 +1,26 @@
 resource onelogin_roles role1 {
-    name = "role_1"
+    name = "role_1_acctest"
 }
 
 resource onelogin_roles role2 {
-    name = "role_1"
+    name = "role_2_acctest"
 }
 
 resource onelogin_users user1 {
-    username = "testy.mctesterson"
-    email = "testy.mctesterson@onelogin.com"
+    username = "testy.mctesterson.acctest"
+    email = "testy.mctesterson.acctest@example.com"
 }
 
 resource onelogin_users user2 {
-    username = "boaty.mcboatface"
-    email = "boaty.mcboatface@onelogin.com"
+    username = "boaty.mcboatface.acctest"
+    email = "boaty.mcboatface.acctest@example.com"
 }
 
 resource onelogin_privileges super_admin {
   name = "super admin"
   description = "description"
-  user_ids = [user1.id, user2.id]
-  role_ids = [role1.id]
+  user_ids = [tonumber(onelogin_users.user1.id), tonumber(onelogin_users.user2.id)]
+  role_ids = [tonumber(onelogin_roles.role1.id)]
   privilege {
 	statement {
 		effect = "Allow"

--- a/examples/onelogin_privilege_updated_example.tf
+++ b/examples/onelogin_privilege_updated_example.tf
@@ -1,26 +1,26 @@
 resource onelogin_roles role1 {
-    name = "role_1"
+    name = "role_1_acctest"
 }
 
 resource onelogin_roles role2 {
-    name = "role_1"
+    name = "role_2_acctest"
 }
 
 resource onelogin_users user1 {
-    username = "testy.mctesterson"
-    email = "testy.mctesterson@onelogin.com"
+    username = "testy.mctesterson.acctest"
+    email = "testy.mctesterson.acctest@example.com"
 }
 
 resource onelogin_users user2 {
-    username = "boaty.mcboatface"
-    email = "boaty.mcboatface@onelogin.com"
+    username = "boaty.mcboatface.acctest"
+    email = "boaty.mcboatface.acctest@example.com"
 }
 
 resource onelogin_privileges super_admin {
-  name = "super admin"
+  name = "super duper admin"
   description = "description"
-  user_ids = [user1.id]
-  role_ids = [role2.id]
+  user_ids = [tonumber(onelogin_users.user1.id)]
+  role_ids = [tonumber(onelogin_roles.role2.id)]
   privilege {
 	statement {
 		effect = "Allow"

--- a/ol_schema/user/user.go
+++ b/ol_schema/user/user.go
@@ -125,15 +125,48 @@ func Schema() map[string]*schema.Schema {
 			Computed: true,
 			Optional: true,
 		},
+		// Read-only timestamps the API returns. userRead has always named these
+		// in the list it hands to SetResourceFields, and d.Set panics on a key
+		// the schema does not declare -- so every create panicked the provider
+		// the moment the API returned one.
+		"created_at": &schema.Schema{
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"updated_at": &schema.Schema{
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"activated_at": &schema.Schema{
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		// Computed only. userRead has always set this and userCreate has always
+		// passed it to Inflate, but nothing declared it and Inflate ignores it,
+		// so it was a panic on read and a no-op on write. Exposing it read-only
+		// makes the read work without claiming an assignment path that does not
+		// exist -- roles are assigned through onelogin_roles.users.
+		"role_ids": &schema.Schema{
+			Type:     schema.TypeList,
+			Computed: true,
+			Elem:     &schema.Schema{Type: schema.TypeInt},
+		},
 		"password": &schema.Schema{
 			Type:        schema.TypeString,
 			Optional:    true,
 			Sensitive:   true,
 			Description: "The user's password. This field is sensitive and will not be displayed in logs or output.",
 		},
+		// Computed as well as Optional. userRead populates this from the API,
+		// which returns every custom attribute defined on the tenant -- with a
+		// null value for the ones this user has not set. Against a
+		// configuration that names none, Optional alone means an empty map
+		// versus a populated one, so every plan proposes removing attributes
+		// nobody asked about and no apply settles it.
 		"custom_attributes": &schema.Schema{
 			Type:        schema.TypeMap,
 			Optional:    true,
+			Computed:    true,
 			Elem:        &schema.Schema{Type: schema.TypeString},
 			Description: "Map of custom attribute key/value pairs. This field is being deprecated in favor of the onelogin_user_custom_attributes resource.",
 		},

--- a/onelogin/resource_onelogin_privileges_test.go
+++ b/onelogin/resource_onelogin_privileges_test.go
@@ -7,8 +7,13 @@ import (
 )
 
 func TestAccPrivilege_crud(t *testing.T) {
-	base := GetFixture("onelogin_privilege_example.tf", t)
-	update := GetFixture("onelogin_privilege_updated_example.tf", t)
+	// One suffix across both steps: loaded separately, step 2 would get a
+	// different one and replace every resource instead of updating them.
+	fixtures := GetFixtures([]string{
+		"onelogin_privilege_example.tf",
+		"onelogin_privilege_updated_example.tf",
+	}, t)
+	base, update := fixtures[0], fixtures[1]
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { TestAccPreCheck(t) },
@@ -19,8 +24,14 @@ func TestAccPrivilege_crud(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("onelogin_privileges.super_admin", "name", "super admin"),
 					resource.TestCheckResourceAttr("onelogin_privileges.super_admin", "description", "description"),
-					resource.TestCheckResourceAttr("onelogin_privileges.super_admin", "privilege.statement.0.action.0", "apps:List"),
-					resource.TestCheckResourceAttr("onelogin_privileges.super_admin", "privilege.statement.0.action.1", "users:List"),
+					// privilege is a TypeSet, so its members are keyed by hash
+					// rather than index: "privilege.statement.0..." can never
+					// match. TestCheckTypeSetElemNestedAttrs searches the set.
+					resource.TestCheckResourceAttr("onelogin_privileges.super_admin", "privilege.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs("onelogin_privileges.super_admin", "privilege.*", map[string]string{
+						"statement.0.action.0": "apps:List",
+						"statement.1.action.0": "users:List",
+					}),
 				),
 			},
 			{
@@ -28,8 +39,11 @@ func TestAccPrivilege_crud(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("onelogin_privileges.super_admin", "name", "super duper admin"),
 					resource.TestCheckResourceAttr("onelogin_privileges.super_admin", "description", "description"),
-					resource.TestCheckResourceAttr("onelogin_privileges.super_admin", "privilege.statement.0.action.0", "apps:List"),
-					resource.TestCheckResourceAttr("onelogin_privileges.super_admin", "privilege.statement.0.action.1", "users:List"),
+					resource.TestCheckResourceAttr("onelogin_privileges.super_admin", "privilege.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs("onelogin_privileges.super_admin", "privilege.*", map[string]string{
+						"statement.0.action.0": "apps:List",
+						"statement.1.action.0": "users:List",
+					}),
 				),
 			},
 		},

--- a/onelogin/tf_test_fixture.go
+++ b/onelogin/tf_test_fixture.go
@@ -2,7 +2,6 @@ package onelogin
 
 import (
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -49,7 +48,7 @@ func getFixtureWithSuffix(name, suffix string, t *testing.T) string {
 	t.Helper()
 
 	_, filename, _, _ := runtime.Caller(0)
-	p := path.Join(filepath.Dir(filename), "../examples", name)
+	p := filepath.Join(filepath.Dir(filename), "..", "examples", name)
 
 	rawFile, err := os.ReadFile(p)
 	if err != nil {

--- a/onelogin/tf_test_fixture.go
+++ b/onelogin/tf_test_fixture.go
@@ -1,27 +1,60 @@
 package onelogin
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 )
 
-// GetFixture returns the HCL example to be used in an acceptance test
+// fixtureUniqueToken is replaced in every fixture with a value unique to the
+// run. Fixtures in examples/ are documentation as well as test input, so they
+// carry readable names — but OneLogin enforces uniqueness on usernames and
+// emails within a tenant, and a fixture that hard-codes them passes once and
+// fails on every run afterwards with:
+//
+//	Validation failed: Email must be unique within <tenant>,
+//	Username must be unique within <tenant>
+//
+// A token keeps the examples readable while letting the suite be re-run.
+const fixtureUniqueToken = "acctest"
+
+// GetFixture returns the HCL example to be used in an acceptance test, with
+// fixtureUniqueToken replaced by a value unique to this run.
 func GetFixture(name string, t *testing.T) string {
+	t.Helper()
+	return getFixtureWithSuffix(name, acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum), t)
+}
+
+// GetFixtures returns several fixtures sharing one suffix, for a test whose
+// steps must refer to the same resources. Loading them separately would give
+// each step a different suffix, and the second step would replace every
+// resource rather than updating it.
+func GetFixtures(names []string, t *testing.T) []string {
+	t.Helper()
+	suffix := acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum)
+
+	out := make([]string, 0, len(names))
+	for _, name := range names {
+		out = append(out, getFixtureWithSuffix(name, suffix, t))
+	}
+	return out
+}
+
+func getFixtureWithSuffix(name, suffix string, t *testing.T) string {
+	t.Helper()
+
 	_, filename, _, _ := runtime.Caller(0)
-	exPath := filepath.Dir(filename)
-	p := path.Join(exPath, "../examples", name)
-	file, err := os.Open(p)
+	p := path.Join(filepath.Dir(filename), "../examples", name)
+
+	rawFile, err := os.ReadFile(p)
 	if err != nil {
-		t.Fatalf("failed to load fixture for acceptance test")
+		t.Fatalf("failed to load fixture %s for acceptance test: %v", name, err)
 	}
-	rawFile, err := ioutil.ReadAll(file)
-	if err != nil {
-		t.Fatalf("failed to read fixture for acceptance test")
-	}
-	tfConfig := string(rawFile)
-	return tfConfig
+
+	return strings.ReplaceAll(string(rawFile), fixtureUniqueToken, suffix)
 }

--- a/utils/resource_utils.go
+++ b/utils/resource_utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"context"
 	"fmt"
+	"log"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -61,13 +62,38 @@ func StandardDeleteFunc(
 	return nil
 }
 
-// SetResourceFields sets multiple fields from a map to ResourceData
+// SetResourceFields sets multiple fields from a map to ResourceData.
+//
+// A field the schema does not declare is skipped rather than set. d.Set panics
+// on an unknown key -- "Invalid address to set" -- so a name in a caller's list
+// that is not in its schema crashes the provider process rather than reporting
+// anything, and it does so on the read path, which create calls. That is how
+// onelogin_users panicked on every create: its list named created_at,
+// updated_at and activated_at, none of which the schema had.
+//
+// Skipping is the safe direction. The alternative is a panic in somebody's
+// pipeline over a field they never asked for.
 func SetResourceFields(d *schema.ResourceData, data map[string]interface{}, fields []string) {
 	for _, field := range fields {
-		if value, exists := data[field]; exists {
-			d.Set(field, value)
+		value, exists := data[field]
+		if !exists {
+			continue
+		}
+		if err := setIfDeclared(d, field, value); err != nil {
+			log.Printf("[WARN] could not set %q: %v", field, err)
 		}
 	}
+}
+
+// setIfDeclared sets a field, turning the panic d.Set raises for an undeclared
+// key into an error the caller can log.
+func setIfDeclared(d *schema.ResourceData, field string, value interface{}) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("%q is not in this resource's schema: %v", field, r)
+		}
+	}()
+	return d.Set(field, value)
 }
 
 // SetNestedFields sets multiple nested fields from a map

--- a/utils/resource_utils.go
+++ b/utils/resource_utils.go
@@ -85,12 +85,17 @@ func SetResourceFields(d *schema.ResourceData, data map[string]interface{}, fiel
 	}
 }
 
-// setIfDeclared sets a field, turning the panic d.Set raises for an undeclared
-// key into an error the caller can log.
+// setIfDeclared sets a field, turning a panic from d.Set into an error the
+// caller can log rather than a crash.
+//
+// The panic is reported verbatim rather than being attributed. An undeclared
+// key is the reason it was written -- d.Set raises "Invalid address to set" --
+// but recover() catches everything, and naming a cause the panic may not have
+// would mislabel the next one and hide whatever it really was.
 func setIfDeclared(d *schema.ResourceData, field string, value interface{}) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("%q is not in this resource's schema: %v", field, r)
+			err = fmt.Errorf("setting %q panicked: %v", field, r)
 		}
 	}()
 	return d.Set(field, value)


### PR DESCRIPTION
First fruits of #248, which made the acceptance suite runnable. Repairing **one** test surfaced **three real defects in `onelogin_users`** that unit tests cannot see.

This is deliberately not the whole of the fixture repair — see the honest status at the end.

## `onelogin_users` panicked on create

`d.Set` panics on a key the schema does not declare — *"Invalid address to set"*. `userRead` named `created_at`, `updated_at` and `activated_at` in the list it hands to `SetResourceFields`, and set `role_ids` directly. **The schema declared none of the four.**

```
panic: Invalid address to set: []string{"created_at"}
  utils.SetResourceFields   resource_utils.go:68
  onelogin.userRead         resource_onelogin_users.go:177
  onelogin.userCreate       resource_onelogin_users.go:125
```

It is on the create path, because create calls read. All four are now `Computed`.

`role_ids` is read-only rather than configurable: `userCreate` has always passed it to `Inflate` and `Inflate` has always ignored it, so accepting it would promise an assignment path that does not exist. Roles are assigned through `onelogin_roles.users`.

## `SetResourceFields` can no longer panic

It skips an undeclared field and logs, rather than crashing. The alternative is a panic in somebody's pipeline over a field they never asked for — the same reasoning as #247, and this is the second instance of that class today.

## `custom_attributes` diffed on every plan

`userRead` populates it from the API, which returns **every custom attribute defined on the tenant**, with a `null` for the ones a user has not set. Against a configuration naming none, `Optional`-only meant an empty map versus a populated one:

```
~ resource "onelogin_users" "user1" {
    ~ custom_attributes = {
        - "apples"           = null
        - "banana"           = null
        - "manager_username" = null
```

Now `Optional` **and** `Computed` — precisely the shape fixed for `sso` in #246. That is the fourth sighting of this pattern.

## Fixtures needed unique names

Fixtures in `examples/` are documentation *and* test input, so they hard-code readable names. OneLogin enforces uniqueness on usernames and emails within a tenant, so the suite passes once and fails forever after:

```
Validation failed: Email must be unique within chicken, Username must be unique within chicken
```

`GetFixture` now substitutes a per-run token. `GetFixtures` shares one suffix across a test's steps — loading them separately would give step two a different suffix, and it would replace every resource rather than update it.

The privilege fixtures were separately wrong: references were bare (`user1.id` rather than `onelogin_users.user1.id`, which Terraform reads as a resource *of type* `user1`), IDs are strings where the schema wants ints, and the "updated" fixture never changed the name its own test asserts on after the update.

## Honest status

`TestAccPrivilege_crud` still fails, on a **fifth** defect this uncovered: `onelogin_privileges` does not round-trip its `privilege` block. After apply and refresh the whole block reads as removed, so `privilegeRead` is not flattening it back into state. That deserves its own investigation rather than being tacked on here.

Suite status against a development tenant: `TestAccRole_crud`, `TestAccUserCustomAttributes_basic` and `TestAccUserCustomAttributes_position` pass; the rest still fail on their own fixtures or on defects like the above. **No test regressed** — I verified a suspected regression in `TestAccUserCustomAttributes_basic` and found it was litter from an earlier run, not my change.

## Testing

- `make test`, `go build`, `go vet`, `gofmt` clean; CI unaffected since it runs `-short`.
- Verified against a live development tenant: the panic is gone, the `custom_attributes` diff is gone, and the two passing custom-attribute tests still pass after the schema changes.