### PR TITLE
fix: read the privilege version under the key the API returns

### DIFF
--- a/ol_schema/privilege/privilege.go
+++ b/ol_schema/privilege/privilege.go
@@ -8,6 +8,11 @@ import (
 )
 
 // Schema returns a key/value map of the various fields that make up a Privilege at OneLogin.
+// DefaultVersion is the privilege document version used when a configuration
+// does not name one, and when a response omits it. Defined here so the schema
+// default and privilegeRead's fallback cannot drift apart.
+const DefaultVersion = "2018-05-18"
+
 func Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"name": &schema.Schema{
@@ -36,7 +41,7 @@ func Schema() map[string]*schema.Schema {
 					"version": &schema.Schema{
 						Type:     schema.TypeString,
 						Optional: true,
-						Default:  "2018-05-18",
+						Default:  DefaultVersion,
 					},
 					"statement": &schema.Schema{
 						Type:     schema.TypeList,

--- a/onelogin/resource_onelogin_privileges.go
+++ b/onelogin/resource_onelogin_privileges.go
@@ -119,9 +119,22 @@ func privilegeRead(ctx context.Context, d *schema.ResourceData, m interface{}) d
 				}
 			}
 
+			// "Version", not "version". The API capitalises every key inside
+			// the privilege document -- Version, Statement, Effect, Action,
+			// Scope -- and the statement keys above already account for that.
+			// Reading a lower-case "version" yielded nil, so the block written
+			// to state never matched the configuration and every plan after an
+			// apply proposed replacing the whole privilege.
+			version := privilegeData["Version"]
+			if version == nil {
+				// Older responses, and anything that omits it, fall back to the
+				// schema's default rather than writing a nil into state.
+				version = "2018-05-18"
+			}
+
 			d.Set("privilege", []map[string]interface{}{
 				{
-					"version":   privilegeData["version"],
+					"version":   version,
 					"statement": statements,
 				},
 			})

--- a/onelogin/resource_onelogin_privileges.go
+++ b/onelogin/resource_onelogin_privileges.go
@@ -128,8 +128,9 @@ func privilegeRead(ctx context.Context, d *schema.ResourceData, m interface{}) d
 			version := privilegeData["Version"]
 			if version == nil {
 				// Older responses, and anything that omits it, fall back to the
-				// schema's default rather than writing a nil into state.
-				version = "2018-05-18"
+				// schema's default rather than writing a nil into state. Taken
+				// from the schema package so the two cannot drift.
+				version = privilegeschema.DefaultVersion
 			}
 
 			d.Set("privilege", []map[string]interface{}{


### PR DESCRIPTION
Found by the acceptance suite that #248 made runnable, and fixed by one character.

## The bug

`privilegeRead` read `privilegeData["version"]`. The API returns **`"Version"`**:

```json
"privilege": {
  "Version": "2018-05-18",
  "Statement": [ { "Effect": "Allow", "Action": ["apps:List"], "Scope": ["*"] } ]
}
```

Every key inside the privilege document is capitalised, and the statement keys immediately above this line already accounted for that — `Statement`, `Effect`, `Action`, `Scope` were all correct. Only `version` was lower case.

## Why it mattered more than a typo should

The read wrote a `nil` version into state. The block therefore never matched the configuration, so **every plan after an apply proposed replacing the whole privilege**:

```
~ resource "onelogin_privileges" "super_admin" {
    - privilege {
        - statement {
            - action = [ - "apps:List", ]
            - effect = "Allow" -> null
```

`onelogin_privileges` never converged. Applying it repeatedly would have churned the resource forever.

A response that omits the key now falls back to the schema default rather than writing `nil` into state.

## How it was found

`TestAccPrivilege_crud`'s post-apply empty-plan check — the thing acceptance tests do that unit tests structurally cannot. A unit test can confirm the flatten function maps keys; only a real apply-then-plan shows that the resulting state does not match the configuration it came from.

Verified against a development tenant: the `GET` output above is real, and the test now passes including that check.

## Suite status

```
PASS  TestAccPrivilege_crud          <- this PR
PASS  TestAccRole_crud
PASS  TestAccUserCustomAttributes_basic
PASS  TestAccUserCustomAttributes_position
```

Four passing, twelve still failing, two skipped. The remaining failures follow the same pattern: a fixture that drifted, often concealing a real defect behind it. I am taking them one per PR — each is a genuine bug that deserves reviewing on its own rather than being buried in a batch.

## Testing

- `make test`, `go build`, `go vet`, `gofmt` clean. CI is unaffected; it runs `-short`.
- `TestAccPrivilege_crud` against a live development tenant.