### PR TITLE
fix: repair the acceptance fixtures, and the provider bugs they were hiding

### DIFF
--- a/examples/onelogin_app_rules_example.tf
+++ b/examples/onelogin_app_rules_example.tf
@@ -8,6 +8,14 @@ resource onelogin_saml_apps saml{
   }
 }
 
+# has_role takes a role ID. The example creates the role it checks for rather
+# than naming an ID from somebody else's account: the rules endpoint rejects an
+# ID it does not recognise with a bare 422 and no indication of which value it
+# objected to.
+resource onelogin_roles rule_role{
+  name = "App Rule Example Role acctest"
+}
+
 resource onelogin_app_rules test{
   app_id = onelogin_saml_apps.saml.id
   enabled = true
@@ -32,7 +40,7 @@ resource onelogin_app_rules check{
   conditions {
     operator = "ri"
     source = "has_role"
-    value = "340475"
+    value = onelogin_roles.rule_role.id
   }
   actions {
     action = "set_amazonusername"

--- a/examples/onelogin_app_rules_updated_example.tf
+++ b/examples/onelogin_app_rules_updated_example.tf
@@ -8,6 +8,14 @@ resource onelogin_saml_apps saml{
   }
 }
 
+# has_role takes a role ID. The example creates the role it checks for rather
+# than naming an ID from somebody else's account: the rules endpoint rejects an
+# ID it does not recognise with a bare 422 and no indication of which value it
+# objected to.
+resource onelogin_roles rule_role{
+  name = "App Rule Example Role acctest"
+}
+
 resource onelogin_app_rules test{
   app_id = onelogin_saml_apps.saml.id
   enabled = true
@@ -32,7 +40,7 @@ resource onelogin_app_rules check{
   conditions {
     operator = "ri"
     source = "has_role"
-    value = "340475"
+    value = onelogin_roles.rule_role.id
   }
   actions {
     action = "set_amazonusername"

--- a/examples/onelogin_auth_server_example.tf
+++ b/examples/onelogin_auth_server_example.tf
@@ -1,7 +1,7 @@
 resource onelogin_auth_servers test {
   name = "test"
   description = "test"
-  configuration = {
+  configuration {
     resource_identifier = "https://example.com/contacts"
     audiences = ["https://example.com/contacts"]
     refresh_token_expiration_minutes = 30

--- a/examples/onelogin_auth_server_updated_example.tf
+++ b/examples/onelogin_auth_server_updated_example.tf
@@ -1,7 +1,7 @@
 resource onelogin_auth_servers test {
   name = "updated"
   description = "updated test"
-  configuration = {
+  configuration {
     resource_identifier = "https://example.com/users/contacts"
     audiences = ["https://example.com/contacts", "https://example.com/users/contacts"]
     refresh_token_expiration_minutes = 30

--- a/examples/onelogin_smarthooks_example.tf
+++ b/examples/onelogin_smarthooks_example.tf
@@ -6,9 +6,9 @@ resource onelogin_smarthooks basic_test {
   }
   retries = 0
   timeout = 1
-  runtime =  "nodejs12.x"
+  runtime =  "nodejs22.x"
   disabled = false
-  options = {
+  options {
     risk_enabled = false
     location_enabled = false
   }

--- a/examples/onelogin_smarthooks_updated_example.tf
+++ b/examples/onelogin_smarthooks_updated_example.tf
@@ -6,9 +6,9 @@ resource onelogin_smarthooks basic_test {
   }
   retries = 0
   timeout = 1
-  runtime =  "nodejs12.x"
+  runtime =  "nodejs22.x"
   disabled = false
-  options = {
+  options {
     risk_enabled = false
     location_enabled = false
   }

--- a/examples/onelogin_user_custom_attributes_example.tf
+++ b/examples/onelogin_user_custom_attributes_example.tf
@@ -1,7 +1,7 @@
 # Create a user
 resource onelogin_users test_user {
-  username = "test.user"
-  email    = "test.user@example.com"
+  username = "test.user.acctest"
+  email    = "test.user.acctest@example.com"
 }
 
 # Create a custom attribute definition (schema)

--- a/examples/onelogin_user_example.tf
+++ b/examples/onelogin_user_example.tf
@@ -1,4 +1,4 @@
 resource onelogin_users basic_test {
-  username = "testy.mctesterson"
-  email = "testy.mctesterson@onelogin.com"
+  username = "testy.mctesterson.acctest"
+  email = "testy.mctesterson.acctest@example.com"
 }

--- a/examples/onelogin_user_mapping_example.tf
+++ b/examples/onelogin_user_mapping_example.tf
@@ -13,58 +13,52 @@ provider "onelogin" {
 }
 
 # Basic user mapping that applies a role to users with email domain @example.com
-resource "onelogin_user_mapping" "example_mapping" {
+resource "onelogin_user_mappings" "example_mapping" {
   name     = "Example Domain Mapping"
   match    = "all"                  # Match all conditions
   enabled  = true
-  position = 1                      # Order in which mappings are evaluated
 
   # Condition to check if user's email contains @example.com
   conditions {
     source   = "email"              # User attribute to check
-    operator = "contains"           # Operator for comparison
+    operator = "~"           # Operator for comparison
     value    = "@example.com"       # Value to compare against
   }
 
   # Action to assign a role to matching users
   # Note: Replace 12345 with actual role ID from your OneLogin account
   actions {
-    action = "set_role"
-    value  = ["12345"]
+    action = "add_role"
+    value  = ["380586"]
   }
 }
 
 # More complex user mapping with multiple conditions and actions
-resource "onelogin_user_mapping" "department_mapping" {
+resource "onelogin_user_mappings" "department_mapping" {
   name     = "Department Based Mapping"
   match    = "all"                  # Match all conditions
   enabled  = true
-  position = 2                      # Processed after the first mapping
 
   # Check if user belongs to IT department
   conditions {
     source   = "department"
-    operator = "equals"
+    operator = "="
     value    = "IT"
   }
 
   # Check if user's title contains "Engineer"
   conditions {
     source   = "title"
-    operator = "contains"
+    operator = "~"
     value    = "Engineer"
   }
 
   # Assign multiple roles to matching users
   # Note: Replace IDs with actual role IDs from your OneLogin account
   actions {
-    action = "set_role"
-    value  = ["23456", "34567"]
+    action = "add_role"
+    value  = ["380586"]
   }
 
   # Set the user's group memberships
-  actions {
-    action = "set_groups"
-    value  = ["Engineers", "IT Staff"]
-  }
 }

--- a/examples/onelogin_user_mapping_example.tf
+++ b/examples/onelogin_user_mapping_example.tf
@@ -12,32 +12,43 @@ provider "onelogin" {
   # Or provide them directly here (not recommended for sensitive values)
 }
 
+# Mappings act on roles, so this example creates the ones it assigns rather than
+# naming IDs from somebody else's account. Point these at your own roles if you
+# already have them -- the API rejects an ID it does not recognise with
+# "Invalid action value(s)".
+resource "onelogin_roles" "mapping_primary" {
+  name = "Mapping Example Primary acctest"
+}
+
+resource "onelogin_roles" "mapping_secondary" {
+  name = "Mapping Example Secondary acctest"
+}
+
 # Basic user mapping that applies a role to users with email domain @example.com
 resource "onelogin_user_mappings" "example_mapping" {
-  name     = "Example Domain Mapping"
-  match    = "all"                  # Match all conditions
-  enabled  = true
+  name    = "Example Domain Mapping"
+  match   = "all" # Match all conditions
+  enabled = true
 
   # Condition to check if user's email contains @example.com
   conditions {
-    source   = "email"              # User attribute to check
-    operator = "~"           # Operator for comparison
-    value    = "@example.com"       # Value to compare against
+    source   = "email"        # User attribute to check
+    operator = "~"            # Operator for comparison
+    value    = "@example.com" # Value to compare against
   }
 
   # Action to assign a role to matching users
-  # Note: Replace 12345 with actual role ID from your OneLogin account
   actions {
     action = "add_role"
-    value  = ["380586"]
+    value  = [onelogin_roles.mapping_primary.id]
   }
 }
 
 # More complex user mapping with multiple conditions and actions
 resource "onelogin_user_mappings" "department_mapping" {
-  name     = "Department Based Mapping"
-  match    = "all"                  # Match all conditions
-  enabled  = true
+  name    = "Department Based Mapping"
+  match   = "all" # Match all conditions
+  enabled = true
 
   # Check if user belongs to IT department
   conditions {
@@ -53,12 +64,8 @@ resource "onelogin_user_mappings" "department_mapping" {
     value    = "Engineer"
   }
 
-  # Assign multiple roles to matching users
-  # Note: Replace IDs with actual role IDs from your OneLogin account
   actions {
     action = "add_role"
-    value  = ["380586"]
+    value  = [onelogin_roles.mapping_primary.id]
   }
-
-  # Set the user's group memberships
 }

--- a/examples/onelogin_user_mapping_updated_example.tf
+++ b/examples/onelogin_user_mapping_updated_example.tf
@@ -12,62 +12,54 @@ provider "onelogin" {
 }
 
 # Updated version of the example mapping
-resource "onelogin_user_mapping" "example_mapping" {
+resource "onelogin_user_mappings" "example_mapping" {
   name     = "Updated Domain Mapping"  # Changed name
   match    = "any"                     # Changed from "all" to "any"
   enabled  = true
-  position = 3                         # Changed position
 
   # Original condition
   conditions {
     source   = "email"
-    operator = "contains"
+    operator = "~"
     value    = "@example.com"
   }
 
   # Added condition
   conditions {
     source   = "email"
-    operator = "contains" 
+    operator = "~" 
     value    = "@partner.com"
   }
 
   # Original action with updated role IDs
   actions {
-    action = "set_role"
-    value  = ["45678"]                # Updated role ID
+    action = "add_role"
+    value  = ["380586"]                # Updated role ID
   }
   
   # Added action to set custom attributes
   actions {
     action = "set_userprincipalname"
-    value  = ["${user.email}"]        # Dynamic value using user's email
+    value  = ["$${user.email}"]        # Dynamic value using user's email
   }
 }
 
 # Updated version of the department mapping with different approach
-resource "onelogin_user_mapping" "department_mapping" {
+resource "onelogin_user_mappings" "department_mapping" {
   name     = "Engineering Team Mapping"  # Updated name
   match    = "all"
   enabled  = true
-  position = 4                           # Updated position
 
   # Simplified condition - now just checking for Engineering department
   conditions {
     source   = "department"
-    operator = "equals"
+    operator = "="
     value    = "Engineering"             # Changed from IT to Engineering
-  }
-
-  # Set specific custom attribute for engineers
-  actions {
-    action = "set_custom_attribute"
-    value  = ["employee_type", "technical"]
   }
 
   # Updated role assignments
   actions {
-    action = "set_role"
+    action = "add_role"
     value  = ["34567", "56789"]          # Updated role IDs
   }
 }

--- a/examples/onelogin_user_mapping_updated_example.tf
+++ b/examples/onelogin_user_mapping_updated_example.tf
@@ -11,11 +11,20 @@ provider "onelogin" {
   # Set these variables with ONELOGIN_CLIENT_ID, ONELOGIN_CLIENT_SECRET environment variables
 }
 
+# Unchanged from the example this updates -- the roles the mappings assign.
+resource "onelogin_roles" "mapping_primary" {
+  name = "Mapping Example Primary acctest"
+}
+
+resource "onelogin_roles" "mapping_secondary" {
+  name = "Mapping Example Secondary acctest"
+}
+
 # Updated version of the example mapping
 resource "onelogin_user_mappings" "example_mapping" {
-  name     = "Updated Domain Mapping"  # Changed name
-  match    = "any"                     # Changed from "all" to "any"
-  enabled  = true
+  name    = "Updated Domain Mapping" # Changed name
+  match   = "any"                    # Changed from "all" to "any"
+  enabled = true
 
   # Original condition
   conditions {
@@ -27,39 +36,47 @@ resource "onelogin_user_mappings" "example_mapping" {
   # Added condition
   conditions {
     source   = "email"
-    operator = "~" 
+    operator = "~"
     value    = "@partner.com"
   }
 
-  # Original action with updated role IDs
   actions {
     action = "add_role"
-    value  = ["380586"]                # Updated role ID
+    value  = [onelogin_roles.mapping_primary.id]
   }
-  
-  # Added action to set custom attributes
+
+  # Added action, using a OneLogin macro rather than a Terraform interpolation.
+  # The doubled $ is HCL's escape: what reaches OneLogin is ${user.email}.
   actions {
     action = "set_userprincipalname"
-    value  = ["$${user.email}"]        # Dynamic value using user's email
+    value  = ["$${user.email}"]
   }
 }
 
 # Updated version of the department mapping with different approach
 resource "onelogin_user_mappings" "department_mapping" {
-  name     = "Engineering Team Mapping"  # Updated name
-  match    = "all"
-  enabled  = true
+  name    = "Engineering Team Mapping" # Updated name
+  match   = "all"
+  enabled = true
 
   # Simplified condition - now just checking for Engineering department
   conditions {
     source   = "department"
     operator = "="
-    value    = "Engineering"             # Changed from IT to Engineering
+    value    = "Engineering" # Changed from IT to Engineering
   }
 
-  # Updated role assignments
+  # Now assigning both roles -- one block each, because add_role takes a single
+  # value. Two IDs in one block are rejected with
+  # "Invalid action value(s): <both ids>", which names the values when what is
+  # actually wrong is the count.
   actions {
     action = "add_role"
-    value  = ["34567", "56789"]          # Updated role IDs
+    value  = [onelogin_roles.mapping_primary.id]
+  }
+
+  actions {
+    action = "add_role"
+    value  = [onelogin_roles.mapping_secondary.id]
   }
 }

--- a/examples/onelogin_user_updated_example.tf
+++ b/examples/onelogin_user_updated_example.tf
@@ -1,4 +1,4 @@
 resource onelogin_users basic_test {
-  username = "boaty.mcboatface"
-  email = "boaty.mcboatface@onelogin.com"
+  username = "boaty.mcboatface.acctest"
+  email = "boaty.mcboatface.acctest@example.com"
 }

--- a/examples/onelogin_user_with_password_example.tf
+++ b/examples/onelogin_user_with_password_example.tf
@@ -1,6 +1,6 @@
 resource onelogin_users user_with_password {
-  username  = "user.with.password"
-  email     = "user.with.password@onelogin.com"
+  username  = "user.with.password.acctest"
+  email     = "user.with.password.acctest@example.com"
   firstname = "User"
   lastname  = "WithPassword"
   password  = "SecurePassword123!"

--- a/examples/onelogin_user_with_trusted_idp_example.tf
+++ b/examples/onelogin_user_with_trusted_idp_example.tf
@@ -1,5 +1,5 @@
 resource onelogin_users trusted_idp_test {
-  username = "trusted.idp.test"
-  email = "trusted.idp.test@onelogin.com"
+  username = "trusted.idp.test.acctest"
+  email = "trusted.idp.test.acctest@example.com"
   trusted_idp_id = 123456
 }

--- a/examples/onelogin_user_without_trusted_idp_example.tf
+++ b/examples/onelogin_user_without_trusted_idp_example.tf
@@ -1,5 +1,5 @@
 resource onelogin_users trusted_idp_test {
-  username = "trusted.idp.test"
-  email = "trusted.idp.test@onelogin.com"
+  username = "trusted.idp.test.acctest"
+  email = "trusted.idp.test.acctest@example.com"
   # trusted_idp_id has been removed
 }

--- a/ol_schema/app/app.go
+++ b/ol_schema/app/app.go
@@ -78,6 +78,7 @@ func Schema() map[string]*schema.Schema {
 			Type:     schema.TypeSet,
 			Optional: true,
 			Computed: true,
+			Set:      appparametersschema.HashByKeyName,
 			Elem: &schema.Resource{
 				Schema: appparametersschema.Schema(),
 			},

--- a/ol_schema/app/configuration/configuration.go
+++ b/ol_schema/app/configuration/configuration.go
@@ -200,13 +200,12 @@ func FlattenOIDC(config models.ConfigurationOpenId) map[string]interface{} {
 		tfOut["refresh_token_expiration_minutes"] = strconv.FormatInt(int64(config.RefreshTokenExpirationMinutes), 10)
 	}
 
-	if config.OidcApplicationType != 0 {
-		tfOut["oidc_application_type"] = strconv.FormatInt(int64(config.OidcApplicationType), 10)
-	}
-
-	if config.TokenEndpointAuthMethod != 0 {
-		tfOut["token_endpoint_auth_method"] = strconv.FormatInt(int64(config.TokenEndpointAuthMethod), 10)
-	}
+	// Always written, unlike the timeouts below. Zero is a real value for both
+	// of these -- application type 0 is Web and auth method 0 is basic -- so
+	// skipping it kept the most common configuration out of state entirely,
+	// and the plan never settled.
+	tfOut["oidc_application_type"] = strconv.FormatInt(int64(config.OidcApplicationType), 10)
+	tfOut["token_endpoint_auth_method"] = strconv.FormatInt(int64(config.TokenEndpointAuthMethod), 10)
 
 	if config.AccessTokenExpirationMinutes != 0 {
 		tfOut["access_token_expiration_minutes"] = strconv.FormatInt(int64(config.AccessTokenExpirationMinutes), 10)
@@ -278,11 +277,18 @@ func Flatten(config map[string]interface{}) map[string]interface{} {
 			tfOut["refresh_token_expiration_minutes"] = strconv.FormatInt(int64(val), 10)
 		}
 
-		if val, ok := config["oidc_application_type"].(float64); ok && val != 0 {
+		// Zero is a real value for both of these -- application type 0 is Web,
+		// auth method 0 is basic -- and the API omits them at zero rather than
+		// returning it. Defaulting to "0" is what an OIDC app without them
+		// actually is, and skipping them kept the commonest configuration out
+		// of state entirely, so the plan never settled.
+		tfOut["oidc_application_type"] = "0"
+		if val, ok := config["oidc_application_type"].(float64); ok {
 			tfOut["oidc_application_type"] = strconv.FormatInt(int64(val), 10)
 		}
 
-		if val, ok := config["token_endpoint_auth_method"].(float64); ok && val != 0 {
+		tfOut["token_endpoint_auth_method"] = "0"
+		if val, ok := config["token_endpoint_auth_method"].(float64); ok {
 			tfOut["token_endpoint_auth_method"] = strconv.FormatInt(int64(val), 10)
 		}
 

--- a/ol_schema/app/configuration/configuration.go
+++ b/ol_schema/app/configuration/configuration.go
@@ -167,6 +167,41 @@ func Inflate(s map[string]interface{}) (interface{}, error) {
 	return map[string]interface{}{}, nil
 }
 
+// RetainManaged narrows a flattened configuration to the keys the practitioner
+// is actually managing.
+//
+// configuration is a TypeMap, and a map has no way to mark an individual key
+// Computed. A key that is in state and not in the configuration is a removal
+// every plan proposes and no apply can settle, because the next read puts it
+// straight back. The API returns its own defaults regardless of what was sent:
+// an OIDC app always comes back with include_amr_claims false and
+// oidc_application_type 0, and a SAML app comes back with a few dozen keys, so
+// recording everything it sends leaves anyone who did not spell out the whole
+// object with a permanent diff.
+//
+// The prior state's key set is the practitioner's. On create it is the planned
+// configuration, on update it is the new one, and on refresh it is whatever the
+// last apply wrote. A key outside it is not managed by this resource, so its
+// value is not recorded and drift in it is not drift in anything the
+// configuration declares. An empty prior state is an import, where there is no
+// configuration to respect yet and the whole object is written.
+func RetainManaged(prior interface{}, flattened map[string]interface{}) map[string]interface{} {
+	managed, ok := prior.(map[string]interface{})
+	if !ok || len(managed) == 0 {
+		return flattened
+	}
+
+	out := make(map[string]interface{}, len(managed))
+	for key := range managed {
+		// Absent from the response rather than nil: a key the API does not
+		// report back is one this provider cannot claim a value for.
+		if val, found := flattened[key]; found {
+			out[key] = val
+		}
+	}
+	return out
+}
+
 // FlattenOIDC takes an instance of ConfigurationOpenId and returns a map of interface{}
 func FlattenOIDC(config models.ConfigurationOpenId) map[string]interface{} {
 	tfOut := map[string]interface{}{}

--- a/ol_schema/app/configuration/configuration_test.go
+++ b/ol_schema/app/configuration/configuration_test.go
@@ -281,8 +281,10 @@ func TestFlattenConfiguration(t *testing.T) {
 				PostLogoutRedirectURI: strPtr(""),
 			},
 			ExpectedOutput: map[string]interface{}{
-				"redirect_uri":             "test",
-				"post_logout_redirect_uri": "",
+				"redirect_uri":               "test",
+				"post_logout_redirect_uri":   "",
+				"oidc_application_type":      "0",
+				"token_endpoint_auth_method": "0",
 			},
 		},
 		"drops a nil post_logout_redirect_uri, which means the app never had URIs": {
@@ -291,6 +293,11 @@ func TestFlattenConfiguration(t *testing.T) {
 			},
 			ExpectedOutput: map[string]interface{}{
 				"redirect_uri": "test",
+				// Written even at zero, which is a real value: application
+				// type 0 is Web and auth method 0 is basic. Omitting them kept
+				// the commonest OIDC configuration out of state.
+				"oidc_application_type":      "0",
+				"token_endpoint_auth_method": "0",
 			},
 		},
 	}
@@ -321,10 +328,13 @@ func TestFlattenGenericConfiguration(t *testing.T) {
 				"redirect_uri":                     "https://example.com/callback",
 				"post_logout_redirect_uri":         "https://example.com/logout",
 				"login_url":                        "https://example.com/login",
+				"oidc_application_type":            "0",
 				"token_endpoint_auth_method":       "1",
 				"access_token_expiration_minutes":  "10",
 				"refresh_token_expiration_minutes": "20",
-				// oidc_application_type is 0, which Flatten drops as a zero value
+				// oidc_application_type 0 is Web, a real value, so it is kept.
+				// This case previously asserted it was dropped, which is the
+				// behaviour that kept the commonest OIDC app from converging.
 			},
 		},
 		"keeps a cleared post_logout_redirect_uri so the plan converges": {
@@ -333,8 +343,10 @@ func TestFlattenGenericConfiguration(t *testing.T) {
 				"post_logout_redirect_uri": "",
 			},
 			ExpectedOutput: map[string]interface{}{
-				"redirect_uri":             "https://example.com/callback",
-				"post_logout_redirect_uri": "",
+				"oidc_application_type":      "0",
+				"token_endpoint_auth_method": "0",
+				"redirect_uri":               "https://example.com/callback",
+				"post_logout_redirect_uri":   "",
 			},
 		},
 		"drops a null post_logout_redirect_uri, which means the app never had URIs": {
@@ -343,7 +355,9 @@ func TestFlattenGenericConfiguration(t *testing.T) {
 				"post_logout_redirect_uri": nil,
 			},
 			ExpectedOutput: map[string]interface{}{
-				"redirect_uri": "https://example.com/callback",
+				"oidc_application_type":      "0",
+				"token_endpoint_auth_method": "0",
+				"redirect_uri":               "https://example.com/callback",
 			},
 		},
 		"flattens comprehensive SAML configuration from API response": {

--- a/ol_schema/app/configuration/retain_managed_test.go
+++ b/ol_schema/app/configuration/retain_managed_test.go
@@ -1,0 +1,69 @@
+package appconfigurationschema
+
+import (
+	"testing"
+)
+
+// TestRetainManaged covers the perpetual diff a TypeMap produces when the API
+// answers with keys the practitioner never wrote. There is no per-key Computed
+// on a map, so every one of those keys is a removal the plan proposes and the
+// next read puts straight back.
+func TestRetainManaged(t *testing.T) {
+	// What the API returns for an OIDC app configured with four keys: its own
+	// defaults come back whether or not they were sent.
+	fromAPI := map[string]interface{}{
+		"redirect_uri":               "https://localhost:3000/callback",
+		"login_url":                  "https://www.test.com",
+		"oidc_application_type":      "0",
+		"token_endpoint_auth_method": "1",
+		"include_amr_claims":         "false",
+	}
+
+	t.Run("drops keys the configuration does not have", func(t *testing.T) {
+		prior := map[string]interface{}{
+			"redirect_uri":               "https://localhost:3000/callback",
+			"login_url":                  "https://www.test.com",
+			"oidc_application_type":      "0",
+			"token_endpoint_auth_method": "1",
+		}
+
+		out := RetainManaged(prior, fromAPI)
+
+		if _, present := out["include_amr_claims"]; present {
+			t.Fatal("expected include_amr_claims to be left out: the API returns it for every OIDC app, and recording one the configuration never mentioned is a diff no apply can settle")
+		}
+		if len(out) != len(prior) {
+			t.Fatalf("expected the four managed keys, got %v", out)
+		}
+	})
+
+	t.Run("records drift in a key the configuration does have", func(t *testing.T) {
+		out := RetainManaged(map[string]interface{}{
+			"login_url": "https://www.stale.com",
+		}, fromAPI)
+
+		if out["login_url"] != "https://www.test.com" {
+			t.Fatalf("expected the value from the API, got %v", out["login_url"])
+		}
+	})
+
+	t.Run("keeps a managed key the API stopped reporting out of state", func(t *testing.T) {
+		out := RetainManaged(map[string]interface{}{"post_logout_redirect_uri": "https://gone"}, fromAPI)
+
+		if _, present := out["post_logout_redirect_uri"]; present {
+			t.Fatal("expected a key absent from the response to be absent from state: the provider has no value to claim for it")
+		}
+	})
+
+	t.Run("writes everything on import", func(t *testing.T) {
+		// An empty prior state is an import: there is no configuration to
+		// respect yet, so the whole object is recorded.
+		for _, prior := range []interface{}{map[string]interface{}{}, nil, "not a map"} {
+			out := RetainManaged(prior, fromAPI)
+
+			if len(out) != len(fromAPI) {
+				t.Fatalf("expected the whole configuration for prior %#v, got %v", prior, out)
+			}
+		}
+	})
+}

--- a/ol_schema/app/parameters/parameter.go
+++ b/ol_schema/app/parameters/parameter.go
@@ -70,6 +70,66 @@ func Schema() map[string]*schema.Schema {
 	}
 }
 
+// HashByKeyName identifies a parameter in the set by its key name alone.
+//
+// The default set hash covers every attribute, and all but param_key_name are
+// Computed. A parameter whose values or user_attribute_macros the practitioner
+// has not written is unknown at plan time, so the element hashes to something
+// Terraform cannot match against the one already in state, and every plan
+// proposes replacing the whole set. Hashing the key name is knowable from the
+// configuration alone, so the element matches and the Computed attributes are
+// then compared one at a time, which is what Optional+Computed is for.
+//
+// param_key_name is the API's own identity for a parameter: the endpoint
+// returns parameters as an object keyed by it, and Inflate builds that object
+// back, so two parameters cannot share one.
+func HashByKeyName(v interface{}) int {
+	param, ok := v.(map[string]interface{})
+	if !ok {
+		return 0
+	}
+	name, _ := param["param_key_name"].(string)
+	return schema.HashString(name)
+}
+
+// RetainManaged narrows flattened parameters to the ones the practitioner is
+// managing.
+//
+// A connector brings its own parameters -- the AWS connector alone adds
+// saml_username, Role and RoleSessionName -- and the app endpoint returns them
+// alongside the configured ones. Recording them puts elements in state that
+// are in no configuration, which every plan then proposes removing and no
+// apply can settle: the PUT merges rather than replaces, so they come straight
+// back.
+//
+// The prior state's key names are the practitioner's. On create they are the
+// planned set, on update the new one, and on refresh whatever the last apply
+// wrote. An empty prior state is an import, where there is no configuration to
+// respect yet and everything the app has is written.
+func RetainManaged(prior interface{}, flattened []map[string]interface{}) []map[string]interface{} {
+	set, ok := prior.(*schema.Set)
+	if !ok || set.Len() == 0 {
+		return flattened
+	}
+
+	managed := make(map[string]bool, set.Len())
+	for _, raw := range set.List() {
+		if param, ok := raw.(map[string]interface{}); ok {
+			if name, ok := param["param_key_name"].(string); ok {
+				managed[name] = true
+			}
+		}
+	}
+
+	out := make([]map[string]interface{}, 0, len(managed))
+	for _, param := range flattened {
+		if name, ok := param["param_key_name"].(string); ok && managed[name] {
+			out = append(out, param)
+		}
+	}
+	return out
+}
+
 // Inflate takes a map of interfaces and uses the fields to construct
 // a Parameter instance.
 func Inflate(s map[string]interface{}) models.Parameter {

--- a/ol_schema/app/parameters/set_identity_test.go
+++ b/ol_schema/app/parameters/set_identity_test.go
@@ -1,0 +1,89 @@
+package appparametersschema
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func paramSet(names ...string) *schema.Set {
+	list := make([]interface{}, 0, len(names))
+	for _, name := range names {
+		list = append(list, map[string]interface{}{"param_key_name": name})
+	}
+	return schema.NewSet(HashByKeyName, list)
+}
+
+// TestHashByKeyName covers the set identity. Every attribute but the key name
+// is Computed, so hashing the whole element makes a parameter whose values are
+// not yet known unmatchable against the one already in state, and each plan
+// proposes replacing the set.
+func TestHashByKeyName(t *testing.T) {
+	configured := map[string]interface{}{
+		"param_key_name": "email",
+		"label":          "Email",
+	}
+	// The same parameter after a read, carrying what the API filled in.
+	fromState := map[string]interface{}{
+		"param_key_name":            "email",
+		"label":                     "Email",
+		"param_id":                  369278,
+		"values":                    "user.email",
+		"user_attribute_mappings":   "email",
+		"include_in_saml_assertion": true,
+	}
+
+	if HashByKeyName(configured) != HashByKeyName(fromState) {
+		t.Fatal("expected a parameter to hash the same before and after the API fills in its Computed attributes")
+	}
+	if HashByKeyName(configured) == HashByKeyName(map[string]interface{}{"param_key_name": "firstname"}) {
+		t.Fatal("expected different key names to hash differently")
+	}
+	if HashByKeyName("not a parameter") != 0 {
+		t.Fatal("expected an unexpected shape to hash to zero rather than panic")
+	}
+}
+
+// TestRetainManaged covers the parameters a connector brings with it. The AWS
+// connector alone adds saml_username, Role and RoleSessionName; they are in no
+// configuration, and the app PUT merges rather than replaces, so recording them
+// is a removal every plan proposes and no apply can settle.
+func TestRetainManaged(t *testing.T) {
+	fromAPI := []map[string]interface{}{
+		{"param_key_name": "email", "label": "Email"},
+		{"param_key_name": "firstname", "label": "First Name"},
+		{"param_key_name": "saml_username", "label": "Amazon Username"},
+		{"param_key_name": "https://aws.amazon.com/SAML/Attributes/Role", "label": "Role"},
+	}
+
+	t.Run("keeps only the configured parameters", func(t *testing.T) {
+		out := RetainManaged(paramSet("email", "firstname"), fromAPI)
+
+		if len(out) != 2 {
+			t.Fatalf("expected the two configured parameters, got %v", out)
+		}
+		for _, param := range out {
+			if name := param["param_key_name"]; name == "saml_username" {
+				t.Fatalf("expected the connector's own parameters to be left out, got %v", name)
+			}
+		}
+	})
+
+	t.Run("drops a configured parameter the app no longer has", func(t *testing.T) {
+		out := RetainManaged(paramSet("email", "department"), fromAPI)
+
+		if len(out) != 1 || out[0]["param_key_name"] != "email" {
+			t.Fatalf("expected only the parameter the API still reports, got %v", out)
+		}
+	})
+
+	t.Run("writes everything on import", func(t *testing.T) {
+		for _, prior := range []interface{}{paramSet(), nil, "not a set"} {
+			out := RetainManaged(prior, fromAPI)
+
+			if len(out) != len(fromAPI) {
+				t.Fatalf("expected every parameter for prior %#v, got %v", prior, out)
+			}
+		}
+	})
+}

--- a/ol_schema/privilege/privilege.go
+++ b/ol_schema/privilege/privilege.go
@@ -102,6 +102,12 @@ func statementsFromState(prior interface{}) []map[string]interface{} {
 // statementKey identifies a statement by its contents. The action and scope
 // lists are sorted for the comparison only -- the values written to state are
 // the ones the API returned, untouched.
+//
+// Untouched is safe: unlike the statements themselves, the API preserves the
+// order of the values inside one. A statement created with
+// ["users:List","users:Get","users:Update","users:Delete"] comes back in that
+// order on every read. Sorting here just means a statement is still recognised
+// if that ever stops being true.
 func statementKey(statement map[string]interface{}) string {
 	parts := []string{fmt.Sprint(statement["effect"])}
 

--- a/ol_schema/privilege/privilege.go
+++ b/ol_schema/privilege/privilege.go
@@ -2,6 +2,9 @@ package privilegeschema
 
 import (
 	"errors"
+	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/onelogin/onelogin-go-sdk/v4/pkg/onelogin/models"
@@ -12,6 +15,116 @@ import (
 // does not name one, and when a response omits it. Defined here so the schema
 // default and privilegeRead's fallback cannot drift apart.
 const DefaultVersion = "2018-05-18"
+
+// OrderStatementsLikeState puts the statements a read returned into the order
+// the configuration already has them in.
+//
+// statement is a TypeList, so the order of a document's statements is part of
+// the value -- but the API does not preserve it. The same privilege comes back
+// with its statements in a different order from one read to the next, so a
+// configuration whose statements happen to come back swapped plans a
+// replacement of the whole block, and the read after that may swap them again.
+// The acceptance test failed roughly every other run for exactly this reason,
+// which read as a test isolation problem and was not one.
+//
+// Matching the order already in state is not pretending the documents agree:
+// the statements are compared on their contents, and only ones that are
+// genuinely the same statement are moved. Anything the configuration does not
+// have keeps the order the API gave it. An empty prior state is an import,
+// where there is no order to respect yet.
+//
+// A set would express "unordered" properly, and is the right fix whenever the
+// schema can take a breaking change.
+func OrderStatementsLikeState(prior interface{}, statements []map[string]interface{}) []map[string]interface{} {
+	priorStatements := statementsFromState(prior)
+	if len(priorStatements) == 0 {
+		return statements
+	}
+
+	used := make([]bool, len(statements))
+	out := make([]map[string]interface{}, 0, len(statements))
+
+	for _, priorStatement := range priorStatements {
+		key := statementKey(priorStatement)
+		for i, statement := range statements {
+			if !used[i] && statementKey(statement) == key {
+				used[i] = true
+				out = append(out, statement)
+				break
+			}
+		}
+	}
+
+	for i, statement := range statements {
+		if !used[i] {
+			out = append(out, statement)
+		}
+	}
+	return out
+}
+
+// statementsFromState digs the statement blocks out of a privilege as Terraform
+// holds it: one document, which holds the list of statements.
+//
+// privilege is declared as a TypeSet -- only ever with one element, to give the
+// block a name -- so a read gets a *schema.Set. The list form is accepted too,
+// for callers that build the value by hand.
+func statementsFromState(prior interface{}) []map[string]interface{} {
+	var documents []interface{}
+	switch typed := prior.(type) {
+	case *schema.Set:
+		documents = typed.List()
+	case []interface{}:
+		documents = typed
+	}
+	if len(documents) == 0 {
+		return nil
+	}
+	document, ok := documents[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	raw, ok := document["statement"].([]interface{})
+	if !ok {
+		return nil
+	}
+
+	out := make([]map[string]interface{}, 0, len(raw))
+	for _, item := range raw {
+		if statement, ok := item.(map[string]interface{}); ok {
+			out = append(out, statement)
+		}
+	}
+	return out
+}
+
+// statementKey identifies a statement by its contents. The action and scope
+// lists are sorted for the comparison only -- the values written to state are
+// the ones the API returned, untouched.
+func statementKey(statement map[string]interface{}) string {
+	parts := []string{fmt.Sprint(statement["effect"])}
+
+	for _, field := range []string{"action", "scope"} {
+		values := toStrings(statement[field])
+		sort.Strings(values)
+		parts = append(parts, strings.Join(values, ","))
+	}
+	return strings.Join(parts, "|")
+}
+
+func toStrings(value interface{}) []string {
+	items, ok := value.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		out = append(out, fmt.Sprint(item))
+	}
+	return out
+}
 
 func Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{

--- a/ol_schema/privilege/statement_order_test.go
+++ b/ol_schema/privilege/statement_order_test.go
@@ -1,0 +1,90 @@
+package privilegeschema
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func statement(effect string, actions ...string) map[string]interface{} {
+	acts := make([]interface{}, 0, len(actions))
+	for _, action := range actions {
+		acts = append(acts, action)
+	}
+	return map[string]interface{}{
+		"effect": effect,
+		"action": acts,
+		"scope":  []interface{}{"*"},
+	}
+}
+
+// priorPrivilege builds the value d.Get("privilege") returns: a set of one
+// document holding the statements in the order the configuration has them.
+func priorPrivilege(statements ...map[string]interface{}) *schema.Set {
+	list := make([]interface{}, 0, len(statements))
+	for _, s := range statements {
+		list = append(list, s)
+	}
+	return schema.NewSet(
+		func(interface{}) int { return 0 },
+		[]interface{}{map[string]interface{}{"version": DefaultVersion, "statement": list}},
+	)
+}
+
+// TestOrderStatementsLikeState covers the intermittent perpetual diff. The API
+// returns the statements in an order of its own, and statement is a TypeList,
+// so a swapped pair reads as a changed value.
+func TestOrderStatementsLikeState(t *testing.T) {
+	apps := statement("Allow", "apps:List")
+	users := statement("Allow", "users:List")
+
+	t.Run("restores the configuration's order", func(t *testing.T) {
+		out := OrderStatementsLikeState(priorPrivilege(apps, users), []map[string]interface{}{users, apps})
+
+		if len(out) != 2 {
+			t.Fatalf("expected both statements, got %v", out)
+		}
+		if statementKey(out[0]) != statementKey(apps) || statementKey(out[1]) != statementKey(users) {
+			t.Fatalf("expected the configuration's order, got %v", out)
+		}
+	})
+
+	t.Run("keeps a statement the configuration does not have", func(t *testing.T) {
+		roles := statement("Deny", "roles:List")
+		out := OrderStatementsLikeState(priorPrivilege(apps), []map[string]interface{}{users, roles, apps})
+
+		if len(out) != 3 {
+			t.Fatalf("expected every statement to survive, got %v", out)
+		}
+		if statementKey(out[0]) != statementKey(apps) {
+			t.Fatalf("expected the matched statement first, got %v", out[0])
+		}
+	})
+
+	t.Run("matches on contents, not position", func(t *testing.T) {
+		// Same statement, actions listed the other way round. Order within a
+		// statement's action list is the practitioner's, so it is compared
+		// order-insensitively but written back untouched.
+		configured := statement("Allow", "apps:List", "users:List")
+		returned := statement("Allow", "users:List", "apps:List")
+
+		out := OrderStatementsLikeState(priorPrivilege(configured), []map[string]interface{}{returned})
+
+		if len(out) != 1 {
+			t.Fatalf("expected the statement to be matched, got %v", out)
+		}
+		if actions := out[0]["action"].([]interface{}); actions[0] != "users:List" {
+			t.Fatalf("expected the API's own values to be written back, got %v", actions)
+		}
+	})
+
+	t.Run("leaves the API order alone on import", func(t *testing.T) {
+		for _, prior := range []interface{}{nil, priorPrivilege(), "not a privilege"} {
+			out := OrderStatementsLikeState(prior, []map[string]interface{}{users, apps})
+
+			if len(out) != 2 || statementKey(out[0]) != statementKey(users) {
+				t.Fatalf("expected the response untouched for prior %#v, got %v", prior, out)
+			}
+		}
+	})
+}

--- a/ol_schema/smarthook/environment_variable/environment_variable_test.go
+++ b/ol_schema/smarthook/environment_variable/environment_variable_test.go
@@ -17,6 +17,32 @@ func TestSmartHookSchema(t *testing.T) {
 	})
 }
 
+// TestInflateUpdateBody pins the shape the update endpoint accepts. It takes
+// the variable's ID from the URL and rejects a body carrying anything but the
+// value, with `instance is not allowed to have the additional property "id"`,
+// so an update that inflates from the resource ID fails every time.
+func TestInflateUpdateBody(t *testing.T) {
+	out := Inflate(map[string]interface{}{"value": "987-654-321"})
+
+	if out.ID != nil {
+		t.Fatalf("expected no id in the update body, got %q", *out.ID)
+	}
+	if out.Name != nil {
+		t.Fatalf("expected no name in the update body, got %q", *out.Name)
+	}
+	if out.Value == nil || *out.Value != "987-654-321" {
+		t.Fatalf("expected the value to be carried through, got %v", out.Value)
+	}
+}
+
+// TestNameForcesNew records that the API cannot rename a variable, so a changed
+// name has to replace it rather than update it.
+func TestNameForcesNew(t *testing.T) {
+	if name := Schema()["name"]; !name.ForceNew {
+		t.Fatal("expected name to be ForceNew: the update endpoint refuses a name outright")
+	}
+}
+
 func TestInflate(t *testing.T) {
 	// Create test variables
 	id := "32f9dfee-a02c-4932-98ec-37838ce62ba0"

--- a/ol_schema/smarthook/environment_variable/environmment_variable.go
+++ b/ol_schema/smarthook/environment_variable/environmment_variable.go
@@ -8,9 +8,14 @@ import (
 // Schema returns a key/value map of the various fields that make up the Environment Variables for a OneLogin SmartHook.
 func Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		// ForceNew because the API has no way to rename one. The update
+		// endpoint accepts a body of nothing but "value" -- it rejects a name
+		// outright -- so a changed name could only ever be silently dropped,
+		// leaving the configuration and the variable permanently disagreeing.
 		"name": &schema.Schema{
 			Type:     schema.TypeString,
 			Required: true,
+			ForceNew: true,
 		},
 		"value": &schema.Schema{
 			Type:     schema.TypeString,

--- a/ol_schema/smarthook/options_inflate_test.go
+++ b/ol_schema/smarthook/options_inflate_test.go
@@ -1,0 +1,106 @@
+package smarthooksschema
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	smarthookoptions "github.com/onelogin/terraform-provider-onelogin/ol_schema/smarthook/options"
+)
+
+// optionsSet builds the shape Terraform actually hands to Inflate for a
+// TypeSet of a nested resource. The existing Inflate tests pass a bare map,
+// which is the shape a caller building input by hand uses -- and is why the
+// original code asserting map[string]interface{} survived: nothing ever gave
+// it the set.
+func optionsSet(elems ...map[string]interface{}) *schema.Set {
+	list := make([]interface{}, 0, len(elems))
+	for _, e := range elems {
+		list = append(list, e)
+	}
+	return schema.NewSet(schema.HashResource(&schema.Resource{
+		Schema: smarthookoptions.Schema(),
+	}), list)
+}
+
+// TestInflateOptionsFromSet covers the shape that panicked.
+//
+// options is a TypeSet, so Terraform produces a *schema.Set. Inflate asserted
+// map[string]interface{} on it, which panics -- and no fixture reached that
+// code because the fixtures used pre-0.12 syntax and never parsed.
+func TestInflateOptionsFromSet(t *testing.T) {
+	t.Run("reads the set Terraform produces", func(t *testing.T) {
+		out := Inflate(map[string]interface{}{
+			"type": "pre-authentication",
+			"options": optionsSet(map[string]interface{}{
+				"risk_enabled":     true,
+				"location_enabled": true,
+			}),
+		})
+
+		if out.Options == nil {
+			t.Fatal("expected options to be read from the set")
+		}
+		if out.Options.RiskEnabled == nil || !*out.Options.RiskEnabled {
+			t.Fatalf("expected risk_enabled true, got %v", out.Options.RiskEnabled)
+		}
+		if out.Options.LocationEnabled == nil || !*out.Options.LocationEnabled {
+			t.Fatalf("expected location_enabled true, got %v", out.Options.LocationEnabled)
+		}
+	})
+
+	t.Run("still reads a bare map", func(t *testing.T) {
+		// Callers that build the input themselves, including the older tests
+		// in this package, pass the element directly.
+		out := Inflate(map[string]interface{}{
+			"type":    "pre-authentication",
+			"options": map[string]interface{}{"risk_enabled": true},
+		})
+
+		if out.Options == nil || out.Options.RiskEnabled == nil || !*out.Options.RiskEnabled {
+			t.Fatalf("expected the map shape to still work, got %v", out.Options)
+		}
+	})
+
+	t.Run("leaves options unset for an empty set", func(t *testing.T) {
+		out := Inflate(map[string]interface{}{
+			"type":    "pre-authentication",
+			"options": optionsSet(),
+		})
+
+		if out.Options != nil {
+			t.Fatalf("expected no options, got %v", out.Options)
+		}
+	})
+
+	t.Run("does not panic on an unexpected shape", func(t *testing.T) {
+		// The original failure was a panic, so the guard matters more than the
+		// value: a bad shape must be ignored, not crash the provider.
+		for _, bad := range []interface{}{42, "options", []string{"x"}} {
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						t.Fatalf("panicked on %#v: %v", bad, r)
+					}
+				}()
+
+				if out := Inflate(map[string]interface{}{"type": "pre-authentication", "options": bad}); out.Options != nil {
+					t.Fatalf("expected no options for %#v", bad)
+				}
+			}()
+		}
+	})
+}
+
+// TestOptionsSchemaAllowsOneBlock pins MaxItems. The model holds a single
+// Options struct, so a second block cannot be represented — without this,
+// Inflate would silently keep one and discard the rest.
+func TestOptionsSchemaAllowsOneBlock(t *testing.T) {
+	options := Schema()["options"]
+
+	if options == nil {
+		t.Fatal("expected the smarthook schema to have options")
+	}
+	if options.MaxItems != 1 {
+		t.Fatalf("expected MaxItems 1 so a second block is refused at plan time, got %d", options.MaxItems)
+	}
+}

--- a/ol_schema/smarthook/smarthook.go
+++ b/ol_schema/smarthook/smarthook.go
@@ -47,6 +47,7 @@ func Schema() map[string]*schema.Schema {
 		"options": {
 			Type:     schema.TypeSet,
 			Optional: true,
+			MaxItems: 1,
 			Elem: &schema.Resource{
 				Schema: smarthookoptions.Schema(),
 			},
@@ -156,7 +157,9 @@ func Inflate(s map[string]interface{}) smarthooks.SmartHook {
 	}
 
 	// options is a TypeSet of a nested resource, so Terraform hands this over
-	// as a *schema.Set holding one element. The old code asserted a map, which
+	// as a *schema.Set. The model holds a single Options struct, so the schema
+	// sets MaxItems: 1 and a second block is refused at plan time rather than
+	// being dropped here. The old code asserted a map, which
 	// panicked the moment anybody set the block -- nothing noticed because the
 	// fixture that would have exercised it used pre-0.12 syntax and never
 	// reached the provider.

--- a/ol_schema/smarthook/smarthook.go
+++ b/ol_schema/smarthook/smarthook.go
@@ -83,6 +83,27 @@ func Schema() map[string]*schema.Schema {
 	}
 }
 
+// inflateOptions reads the options block from either shape it can arrive in:
+// the *schema.Set Terraform produces for a TypeSet, or the element map a
+// caller building the input by hand would pass.
+func inflateOptions(raw interface{}) (smarthooks.Options, bool) {
+	switch v := raw.(type) {
+	case *schema.Set:
+		if v.Len() == 0 {
+			return smarthooks.Options{}, false
+		}
+		first, ok := v.List()[0].(map[string]interface{})
+		if !ok {
+			return smarthooks.Options{}, false
+		}
+		return smarthookoptions.Inflate(first), true
+	case map[string]interface{}:
+		return smarthookoptions.Inflate(v), true
+	default:
+		return smarthooks.Options{}, false
+	}
+}
+
 func validTypes(val interface{}, key string) (warns []string, errs []error) {
 	return utils.OneOfValue(key, val, []string{"pre-authentication", "user-migration"})
 }
@@ -134,8 +155,15 @@ func Inflate(s map[string]interface{}) smarthooks.SmartHook {
 		}
 	}
 
-	if s["options"] != nil {
-		opts := smarthookoptions.Inflate(s["options"].(map[string]interface{}))
+	// options is a TypeSet of a nested resource, so Terraform hands this over
+	// as a *schema.Set holding one element. The old code asserted a map, which
+	// panicked the moment anybody set the block -- nothing noticed because the
+	// fixture that would have exercised it used pre-0.12 syntax and never
+	// reached the provider.
+	//
+	// A bare map is still accepted: callers that build the input themselves,
+	// the unit tests among them, pass the element directly.
+	if opts, ok := inflateOptions(s["options"]); ok {
 		out.Options = &opts
 	}
 

--- a/onelogin/data_source_onelogin_groups.go
+++ b/onelogin/data_source_onelogin_groups.go
@@ -51,10 +51,16 @@ func dataSourceOneLoginGroupsRead(ctx context.Context, d *schema.ResourceData, m
 		return utils.HandleAPIError(ctx, err, utils.ErrorCategoryRead, "OneLogin Groups", "")
 	}
 
-	// Parse the response into a slice of Group models
-	groupsData, ok := resp.([]interface{})
+	// GetGroups calls api/1/groups, which wraps its payload:
+	//
+	//	{"status": {...}, "pagination": {...}, "data": [ ... ]}
+	//
+	// Asserting a bare slice therefore always failed, and this data source
+	// could never have returned anything. A bare slice is still accepted, so
+	// this keeps working if the SDK moves to the v2 path, which returns one.
+	groupsData, ok := groupsFromResponse(resp)
 	if !ok {
-		return diag.Errorf("failed to parse groups response")
+		return diag.Errorf("failed to parse groups response: unexpected shape %T", resp)
 	}
 
 	groups := make([]models.Group, 0, len(groupsData))
@@ -101,4 +107,18 @@ func dataSourceOneLoginGroupsRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	return nil
+}
+
+// groupsFromResponse pulls the group list out of either envelope the API uses:
+// the v1 {"data": [...]} wrapper, or a bare array.
+func groupsFromResponse(resp interface{}) ([]interface{}, bool) {
+	switch v := resp.(type) {
+	case []interface{}:
+		return v, true
+	case map[string]interface{}:
+		if data, ok := v["data"].([]interface{}); ok {
+			return data, true
+		}
+	}
+	return nil, false
 }

--- a/onelogin/provider.go
+++ b/onelogin/provider.go
@@ -3,6 +3,7 @@ package onelogin
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -72,6 +73,29 @@ func Provider() *schema.Provider {
 	}
 }
 
+// subdomainFromURL pulls the tenant subdomain out of the configured API URL.
+//
+// The SDK still asks for ONELOGIN_SUBDOMAIN even though every call goes to
+// ONELOGIN_API_URL, so this exists to satisfy it. A regional API host has no
+// tenant subdomain in it at all, hence the placeholder.
+func subdomainFromURL(url string) (string, error) {
+	parts := strings.Split(strings.TrimPrefix(strings.TrimPrefix(url, "https://"), "http://"), ".")
+
+	switch {
+	case len(parts) > 0 && parts[0] != "" && parts[0] != "api":
+		// Direct subdomain URL (e.g., company.onelogin.com)
+		return parts[0], nil
+	case len(parts) > 1 && parts[0] == "api":
+		// API URL format (e.g., api.us.onelogin.com or api.eu.onelogin.com)
+		if region := parts[1]; region != "us" && region != "eu" {
+			return "", fmt.Errorf("invalid API URL format, expected api.us.onelogin.com or api.eu.onelogin.com, got %q", url)
+		}
+		return "dummy", nil
+	default:
+		return "", fmt.Errorf("could not extract a subdomain from %q, please provide a valid OneLogin URL", url)
+	}
+}
+
 // configProvider configures the provider, and if successful, it returns
 // an interface containing the api client.
 func configProvider(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
@@ -99,24 +123,11 @@ func configProvider(ctx context.Context, d *schema.ResourceData) (interface{}, d
 
 	// Extract subdomain from URL for backward compatibility with SDK's internals
 	// Most SDK functions still use the subdomain internally
-	urlParts := strings.Split(strings.TrimPrefix(strings.TrimPrefix(url, "https://"), "http://"), ".")
-	if len(urlParts) > 0 && urlParts[0] != "api" {
-		// Direct subdomain URL (e.g., company.onelogin.com)
-		extractedSubdomain := urlParts[0]
-		os.Setenv("ONELOGIN_SUBDOMAIN", extractedSubdomain)
-	} else if len(urlParts) > 1 && urlParts[0] == "api" {
-		// API URL format (e.g., api.us.onelogin.com or api.eu.onelogin.com)
-		region := urlParts[1]
-		if region == "us" || region == "eu" {
-			// This is a valid API URL, but we need to set a dummy subdomain
-			// as the SDK still requires ONELOGIN_SUBDOMAIN to be set
-			os.Setenv("ONELOGIN_SUBDOMAIN", "dummy")
-		} else {
-			return nil, diag.Errorf("Invalid API URL format. Expected api.us.onelogin.com or api.eu.onelogin.com")
-		}
-	} else {
-		return nil, diag.Errorf("Could not extract subdomain from URL. Please provide a valid OneLogin URL.")
+	subdomain, err := subdomainFromURL(url)
+	if err != nil {
+		return nil, diag.FromErr(err)
 	}
+	os.Setenv("ONELOGIN_SUBDOMAIN", subdomain)
 
 	// Initialize the SDK
 	client, err := ol.NewOneloginSDK()

--- a/onelogin/provider_subdomain_test.go
+++ b/onelogin/provider_subdomain_test.go
@@ -1,0 +1,35 @@
+package onelogin
+
+import "testing"
+
+// TestSubdomainFromURL pins the shapes the provider accepts for ONELOGIN_API_URL.
+// The SDK still asks for a subdomain even though every call goes to the URL, and
+// this is the only thing that supplies it.
+func TestSubdomainFromURL(t *testing.T) {
+	for _, tc := range []struct {
+		url  string
+		want string
+	}{
+		{"https://chicken.onelogin.com", "chicken"},
+		{"http://chicken.onelogin.com", "chicken"},
+		{"chicken.onelogin.com", "chicken"},
+		// A regional API host carries no tenant subdomain, so the SDK gets a
+		// placeholder to satisfy its own requirement.
+		{"https://api.us.onelogin.com", "dummy"},
+		{"https://api.eu.onelogin.com", "dummy"},
+	} {
+		got, err := subdomainFromURL(tc.url)
+		if err != nil {
+			t.Fatalf("%s: unexpected error %v", tc.url, err)
+		}
+		if got != tc.want {
+			t.Fatalf("%s: expected %q, got %q", tc.url, tc.want, got)
+		}
+	}
+
+	for _, url := range []string{"https://api.ap.onelogin.com", ""} {
+		if got, err := subdomainFromURL(url); err == nil {
+			t.Fatalf("%q: expected an error, got %q", url, got)
+		}
+	}
+}

--- a/onelogin/provider_test.go
+++ b/onelogin/provider_test.go
@@ -46,17 +46,19 @@ func TestAccPreCheck(t *testing.T) {
 		t.Fatal("ONELOGIN_CLIENT_SECRET must be set for acceptance tests")
 	}
 
-	// Check for API URL or subdomain as fallback
-	apiURL := os.Getenv("ONELOGIN_API_URL")
-	subdomain := os.Getenv("ONELOGIN_SUBDOMAIN")
-
-	if apiURL == "" && subdomain == "" {
-		t.Fatal("ONELOGIN_API_URL must be set for acceptance tests")
-	}
-
-	// Warn if using subdomain instead of API URL
-	if apiURL == "" && subdomain != "" {
-		t.Logf("WARNING: Using ONELOGIN_SUBDOMAIN which is deprecated. Please switch to ONELOGIN_API_URL.")
+	// ONELOGIN_API_URL, and only that. This used to accept a bare
+	// ONELOGIN_SUBDOMAIN and log that it was deprecated, which read as though
+	// the older setting still worked -- it does not. The provider's url is
+	// Required, so a run with only a subdomain set gets past this check and
+	// then fails every step with
+	//
+	//	Error: Missing required argument
+	//	The argument "url" is required, but no definition was found.
+	//
+	// and the SDK, given only a subdomain, would aim at
+	// <subdomain>.onelogin.com regardless of which tenant was meant.
+	if v := os.Getenv("ONELOGIN_API_URL"); v == "" {
+		t.Fatal("ONELOGIN_API_URL must be set for acceptance tests: the provider requires a url, and ONELOGIN_SUBDOMAIN alone cannot configure it")
 	}
 
 	// Set a longer timeout for tests (5 minutes) if not already set

--- a/onelogin/resource_onelogin_app_rules_test.go
+++ b/onelogin/resource_onelogin_app_rules_test.go
@@ -7,8 +7,13 @@ import (
 )
 
 func TestAccAppRule_crud(t *testing.T) {
-	base := GetFixture("onelogin_app_rules_example.tf", t)
-	update := GetFixture("onelogin_app_rules_updated_example.tf", t)
+	// One suffix across both steps: the fixtures create the role the second
+	// rule checks for, and separate suffixes would rename it between steps.
+	fixtures := GetFixtures([]string{
+		"onelogin_app_rules_example.tf",
+		"onelogin_app_rules_updated_example.tf",
+	}, t)
+	base, update := fixtures[0], fixtures[1]
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { TestAccPreCheck(t) },

--- a/onelogin/resource_onelogin_apps.go
+++ b/onelogin/resource_onelogin_apps.go
@@ -142,7 +142,7 @@ func appRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Di
 					paramMap[key] = param
 				}
 			}
-			d.Set("parameters", appparametersschema.Flatten(paramMap))
+			d.Set("parameters", appparametersschema.RetainManaged(d.Get("parameters"), appparametersschema.Flatten(paramMap)))
 		}
 	}
 

--- a/onelogin/resource_onelogin_apps_test.go
+++ b/onelogin/resource_onelogin_apps_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -78,9 +79,16 @@ func TestLogicalImplementation(t *testing.T) {
 	var _ schema.UpdateContextFunc = appRes.UpdateContext
 	var _ schema.DeleteContextFunc = appRes.DeleteContext
 
+	// Configure the provider if nothing else in this process has. Relying on
+	// another acceptance test to do it means running this one on its own
+	// skips the whole point of it, silently -- which is how the nil meta it
+	// used to pass went unnoticed for so long.
 	m := testAccProvider.Meta()
 	if m == nil {
-		t.Skip("provider is not configured: nothing has run an acceptance test in this process")
+		if diags := testAccProvider.Configure(ctx, terraform.NewResourceConfigRaw(nil)); diags.HasError() {
+			t.Fatalf("could not configure the provider from the environment: %v", diags)
+		}
+		m = testAccProvider.Meta()
 	}
 
 	defer func() {

--- a/onelogin/resource_onelogin_apps_test.go
+++ b/onelogin/resource_onelogin_apps_test.go
@@ -44,7 +44,19 @@ func testResourceData(t *testing.T, resourceType string, attrs map[string]interf
 	return schema.TestResourceDataRaw(t, r.Schema, attrs)
 }
 
-// TestLogicalImplementation tests the resource implementation
+// TestLogicalImplementation tests the resource implementation.
+//
+// The read is given the provider's own meta rather than nil. Handing it nil
+// guaranteed the panic the test was written to catch -- every read opens with
+// m.(*onelogin.OneloginSDK), and a type assertion on a nil interface panics --
+// and it went unnoticed because Meta() is only non-nil once something has
+// configured the provider. Run alone the body was skipped and the test passed;
+// run after any acceptance test in the same process it failed. Terraform never
+// calls a read with a nil meta, so what it caught was not a real state.
+//
+// With a real client and no ID, the read reaches the API and comes back with
+// diagnostics, which is the thing worth pinning: a read for an app that is not
+// there reports rather than crashes.
 func TestLogicalImplementation(t *testing.T) {
 	// Skip if this is not an acceptance test
 	if testing.Short() {
@@ -60,30 +72,24 @@ func TestLogicalImplementation(t *testing.T) {
 
 	appRes := Apps()
 
-	// Create a provider instance without actually making API calls
-	m := testAccProvider.Meta()
-
-	// Test function signatures and types
-	var diags diag.Diagnostics
-
 	// Verify that the function signatures are compatible with the schema interfaces
 	var _ schema.CreateContextFunc = appRes.CreateContext
 	var _ schema.ReadContextFunc = appRes.ReadContext
 	var _ schema.UpdateContextFunc = appRes.UpdateContext
 	var _ schema.DeleteContextFunc = appRes.DeleteContext
 
-	// We can't actually make API calls in a unit test
-	// But we can verify that the implementations don't panic
-	if m != nil {
-		defer func() {
-			if r := recover(); r != nil {
-				t.Errorf("Panic in implementation: %v", r)
-			}
-		}()
-
-		// These will fail because we're not actually making API calls
-		// But they shouldn't panic
-		diags = appRes.ReadContext(ctx, d, nil)
-		assert.NotNil(t, diags)
+	m := testAccProvider.Meta()
+	if m == nil {
+		t.Skip("provider is not configured: nothing has run an acceptance test in this process")
 	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Panic in implementation: %v", r)
+		}
+	}()
+
+	var diags diag.Diagnostics
+	diags = appRes.ReadContext(ctx, d, m)
+	assert.NotNil(t, diags)
 }

--- a/onelogin/resource_onelogin_groups.go
+++ b/onelogin/resource_onelogin_groups.go
@@ -33,11 +33,12 @@ func resourceOneLoginGroups() *schema.Resource {
 				Required: true,
 			},
 			// The API accepts reference in a create or update payload and
-			// then neither stores nor returns it, so a configuration setting
-			// it plans the same change on every run. Computed keeps an omitted
-			// value from diffing; a set one still will. Whether this attribute
-			// should exist at all is a question for the next major, alongside
-			// the sso change held in #236.
+			// then neither stores nor returns it. Computed keeps an omitted
+			// value from diffing, and the read below leaves a set one alone
+			// rather than clearing it, so a configuration that uses the
+			// attribute still settles. Whether it should exist at all, given
+			// the API does nothing with it, is a question for the next major
+			// alongside the sso change held in #236.
 			"reference": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -124,8 +125,14 @@ func groupRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.
 	if err := d.Set("name", groupMap["name"]); err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set("reference", groupMap["reference"]); err != nil {
-		return diag.FromErr(err)
+	// Absent stays absent. The API drops reference rather than storing it, so
+	// it comes back null on every read, and writing that null cleared whatever
+	// the configuration had asked for -- a removal every plan proposed and the
+	// next read produced again.
+	if reference, present := groupMap["reference"]; present && reference != nil {
+		if err := d.Set("reference", reference); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	return nil

--- a/onelogin/resource_onelogin_groups.go
+++ b/onelogin/resource_onelogin_groups.go
@@ -32,6 +32,12 @@ func resourceOneLoginGroups() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			// The API accepts reference in a create or update payload and
+			// then neither stores nor returns it, so a configuration setting
+			// it plans the same change on every run. Computed keeps an omitted
+			// value from diffing; a set one still will. Whether this attribute
+			// should exist at all is a question for the next major, alongside
+			// the sso change held in #236.
 			"reference": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/onelogin/resource_onelogin_groups_test.go
+++ b/onelogin/resource_onelogin_groups_test.go
@@ -20,14 +20,18 @@ func TestAccOneLoginGroup_crud(t *testing.T) {
 				Config: testAccCheckOneLoginGroupConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("onelogin_groups.test", "name", "Test Group"),
-					resource.TestCheckResourceAttr("onelogin_groups.test", "reference", "test-group"),
+					// The API accepts reference in the payload but does not return it,
+					// so it never reaches state and a round-trip assertion cannot
+					// hold. Left as a presence check rather than deleted, so the
+					// attribute stays covered if the API starts honouring it.
+					resource.TestCheckResourceAttrSet("onelogin_groups.test", "name"),
 				),
 			},
 			{
 				Config: testAccCheckOneLoginGroupConfigUpdated,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("onelogin_groups.test", "name", "Updated Test Group"),
-					resource.TestCheckResourceAttr("onelogin_groups.test", "reference", "updated-test-group"),
+					resource.TestCheckResourceAttrSet("onelogin_groups.test", "name"),
 				),
 			},
 			{
@@ -60,13 +64,11 @@ func testAccCheckOneLoginGroupDestroyed(s *terraform.State) error {
 const testAccCheckOneLoginGroupConfig = `
 resource "onelogin_groups" "test" {
   name      = "Test Group"
-  reference = "test-group"
 }
 `
 
 const testAccCheckOneLoginGroupConfigUpdated = `
 resource "onelogin_groups" "test" {
   name      = "Updated Test Group"
-  reference = "updated-test-group"
 }
 `

--- a/onelogin/resource_onelogin_groups_test.go
+++ b/onelogin/resource_onelogin_groups_test.go
@@ -20,24 +20,28 @@ func TestAccOneLoginGroup_crud(t *testing.T) {
 				Config: testAccCheckOneLoginGroupConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("onelogin_groups.test", "name", "Test Group"),
-					// The API accepts reference in the payload but does not return it,
-					// so it never reaches state and a round-trip assertion cannot
-					// hold. Left as a presence check rather than deleted, so the
-					// attribute stays covered if the API starts honouring it.
-					resource.TestCheckResourceAttrSet("onelogin_groups.test", "name"),
+					// The API drops reference rather than storing it, so this
+					// holds only because the read leaves a configured value
+					// alone instead of writing the null back over it.
+					resource.TestCheckResourceAttr("onelogin_groups.test", "reference", "test-group-ref"),
 				),
 			},
 			{
 				Config: testAccCheckOneLoginGroupConfigUpdated,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("onelogin_groups.test", "name", "Updated Test Group"),
-					resource.TestCheckResourceAttrSet("onelogin_groups.test", "name"),
+					resource.TestCheckResourceAttr("onelogin_groups.test", "reference", "updated-group-ref"),
 				),
 			},
 			{
 				ResourceName:      "onelogin_groups.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+				// reference cannot survive an import: the API never returns
+				// it, and an import has no prior state to preserve it from.
+				// An imported group needs the attribute written back into the
+				// configuration by hand, which is the best the API allows.
+				ImportStateVerifyIgnore: []string{"reference"},
 			},
 		},
 	})
@@ -64,11 +68,13 @@ func testAccCheckOneLoginGroupDestroyed(s *terraform.State) error {
 const testAccCheckOneLoginGroupConfig = `
 resource "onelogin_groups" "test" {
   name      = "Test Group"
+  reference = "test-group-ref"
 }
 `
 
 const testAccCheckOneLoginGroupConfigUpdated = `
 resource "onelogin_groups" "test" {
   name      = "Updated Test Group"
+  reference = "updated-group-ref"
 }
 `

--- a/onelogin/resource_onelogin_oidc_apps.go
+++ b/onelogin/resource_onelogin_oidc_apps.go
@@ -123,7 +123,7 @@ func oidcAppRead(ctx context.Context, d *schema.ResourceData, m interface{}) dia
 	// Handle parameters if they exist
 	if v, ok := appMap["parameters"]; ok {
 		if params, ok := v.(map[string]interface{}); ok {
-			d.Set("parameters", appparametersschema.FlattenV4(params))
+			d.Set("parameters", appparametersschema.RetainManaged(d.Get("parameters"), appparametersschema.FlattenV4(params)))
 		}
 	}
 
@@ -137,7 +137,7 @@ func oidcAppRead(ctx context.Context, d *schema.ResourceData, m interface{}) dia
 	// Handle configuration if it exists
 	if v, ok := appMap["configuration"]; ok {
 		if configData, ok := v.(map[string]interface{}); ok {
-			d.Set("configuration", appconfigurationschema.Flatten(configData))
+			d.Set("configuration", appconfigurationschema.RetainManaged(d.Get("configuration"), appconfigurationschema.Flatten(configData)))
 		}
 	}
 

--- a/onelogin/resource_onelogin_privileges.go
+++ b/onelogin/resource_onelogin_privileges.go
@@ -135,8 +135,10 @@ func privilegeRead(ctx context.Context, d *schema.ResourceData, m interface{}) d
 
 			d.Set("privilege", []map[string]interface{}{
 				{
-					"version":   version,
-					"statement": statements,
+					"version": version,
+					// The API returns the statements in an order of its own,
+					// and a TypeList treats order as part of the value.
+					"statement": privilegeschema.OrderStatementsLikeState(d.Get("privilege"), statements),
 				},
 			})
 		}

--- a/onelogin/resource_onelogin_saml_apps.go
+++ b/onelogin/resource_onelogin_saml_apps.go
@@ -152,7 +152,7 @@ func samlAppRead(ctx context.Context, d *schema.ResourceData, m interface{}) dia
 	// Handle parameters if they exist
 	if v, ok := appMap["parameters"]; ok {
 		if params, ok := v.(map[string]interface{}); ok {
-			d.Set("parameters", appparametersschema.FlattenV4(params))
+			d.Set("parameters", appparametersschema.RetainManaged(d.Get("parameters"), appparametersschema.FlattenV4(params)))
 		}
 	}
 
@@ -172,7 +172,7 @@ func samlAppRead(ctx context.Context, d *schema.ResourceData, m interface{}) dia
 			tflog.Debug(ctx, "Configuration is a map", map[string]interface{}{
 				"config_data": configData,
 			})
-			flattenedConfig := appconfigurationschema.Flatten(configData)
+			flattenedConfig := appconfigurationschema.RetainManaged(d.Get("configuration"), appconfigurationschema.Flatten(configData))
 			tflog.Debug(ctx, "Flattened configuration", map[string]interface{}{
 				"flattened_config": flattenedConfig,
 			})

--- a/onelogin/resource_onelogin_saml_apps_test.go
+++ b/onelogin/resource_onelogin_saml_apps_test.go
@@ -48,24 +48,29 @@ func TestAccSAMLApp_crud(t *testing.T) {
 	})
 }
 
-// checkParameterExists verifies that a parameter with the given key name exists in the SAML app
-func checkParameterExists(resourceName, paramKeyName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		// Create a regex pattern to match the parameter set item
-		pattern := regexp.MustCompile(fmt.Sprintf(`parameters\.\d+\.param_key_name\s*=\s*%s`, paramKeyName))
+// paramKeyName matches the state address of a parameter's key name. parameters
+// is a TypeSet, so the middle element is the set hash rather than an index.
+//
+// The pattern used to end in `\s*=\s*<name>` and was matched against the
+// attribute key, which is only ever an address -- so it matched nothing and no
+// parameter was ever found. The name belongs in the value comparison below,
+// which was already there and never reached.
+var paramKeyName = regexp.MustCompile(`^parameters\.\d+\.param_key_name$`)
 
+// checkParameterExists verifies that a parameter with the given key name exists in the SAML app
+func checkParameterExists(resourceName, keyName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("Resource %s not found", resourceName)
 		}
 
-		// Iterate through all attributes to find matching parameters
 		for k, v := range rs.Primary.Attributes {
-			if pattern.MatchString(k) && v == paramKeyName {
+			if paramKeyName.MatchString(k) && v == keyName {
 				return nil
 			}
 		}
 
-		return fmt.Errorf("Parameter with key_name %s not found in %s", paramKeyName, resourceName)
+		return fmt.Errorf("Parameter with key_name %s not found in %s", keyName, resourceName)
 	}
 }

--- a/onelogin/resource_onelogin_smarthook_environment_variables.go
+++ b/onelogin/resource_onelogin_smarthook_environment_variables.go
@@ -101,8 +101,12 @@ func environmentVariablesRead(ctx context.Context, d *schema.ResourceData, m int
 func environmentVariablesUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*onelogin.OneloginSDK)
 
+	// Only "value". The endpoint takes the variable's ID from the URL and
+	// refuses a body carrying anything else -- both id and name come back as
+	// `instance is not allowed to have the additional property` and a 422 --
+	// so sending the id here meant no environment variable could ever be
+	// updated.
 	envVar := smarthookenvironmentvariablesschema.Inflate(map[string]interface{}{
-		"id":    d.Id(),
 		"value": d.Get("value"),
 	})
 

--- a/onelogin/resource_onelogin_smarthooks_test.go
+++ b/onelogin/resource_onelogin_smarthooks_test.go
@@ -28,6 +28,19 @@ func skipIfHookTypeExists(t *testing.T, hookType string) {
 	if err != nil {
 		t.Fatalf("could not work out the subdomain to check for an existing %s hook: %v", hookType, err)
 	}
+
+	// Put back whatever was there. configProvider sets this from the same URL
+	// moments later, so the value is not in dispute -- but a precheck leaving
+	// the process environment changed makes what a later test sees depend on
+	// whether this one ran, and that is worth not doing.
+	previous, wasSet := os.LookupEnv("ONELOGIN_SUBDOMAIN")
+	t.Cleanup(func() {
+		if wasSet {
+			os.Setenv("ONELOGIN_SUBDOMAIN", previous)
+			return
+		}
+		os.Unsetenv("ONELOGIN_SUBDOMAIN")
+	})
 	os.Setenv("ONELOGIN_SUBDOMAIN", subdomain)
 
 	client, err := ol.NewOneloginSDK()

--- a/onelogin/resource_onelogin_smarthooks_test.go
+++ b/onelogin/resource_onelogin_smarthooks_test.go
@@ -24,6 +24,11 @@ func skipIfHookTypeExists(t *testing.T, hookType string) {
 
 	// The SDK still insists on a subdomain even though every call goes to
 	// ONELOGIN_API_URL, and nothing has configured the provider this early.
+	//
+	// Derived from the URL, with no fallback to a bare ONELOGIN_SUBDOMAIN on
+	// purpose. Given only a subdomain the SDK builds <subdomain>.onelogin.com
+	// -- production -- and this would be the one thing in the run to contact
+	// it, since the provider refuses to configure without a url at all.
 	subdomain, err := subdomainFromURL(os.Getenv("ONELOGIN_API_URL"))
 	if err != nil {
 		t.Fatalf("could not work out the subdomain to check for an existing %s hook: %v", hookType, err)

--- a/onelogin/resource_onelogin_smarthooks_test.go
+++ b/onelogin/resource_onelogin_smarthooks_test.go
@@ -1,17 +1,73 @@
 package onelogin
 
 import (
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	ol "github.com/onelogin/onelogin-go-sdk/v4/pkg/onelogin"
 )
+
+// skipIfHookTypeExists skips when the tenant already has a hook of this type.
+//
+// A synchronous hook is a singleton: creating a second pre-authentication hook
+// is refused with
+//
+//	409 The 'pre-authentication' hook is synchronous and can only have one
+//	defined function
+//
+// so on any tenant with one configured this test cannot run. The alternative is
+// deleting whatever is there, and on a shared tenant that is somebody's live
+// authentication path -- not something to do for a green tick.
+func skipIfHookTypeExists(t *testing.T, hookType string) {
+	t.Helper()
+
+	// The SDK still insists on a subdomain even though every call goes to
+	// ONELOGIN_API_URL, and nothing has configured the provider this early.
+	subdomain, err := subdomainFromURL(os.Getenv("ONELOGIN_API_URL"))
+	if err != nil {
+		t.Fatalf("could not work out the subdomain to check for an existing %s hook: %v", hookType, err)
+	}
+	os.Setenv("ONELOGIN_SUBDOMAIN", subdomain)
+
+	client, err := ol.NewOneloginSDK()
+	if err != nil {
+		t.Fatalf("could not build a client to check for an existing %s hook: %v", hookType, err)
+	}
+
+	result, err := client.ListHooks(nil)
+	if err != nil {
+		t.Fatalf("could not list hooks: %v", err)
+	}
+
+	hooks, ok := result.([]interface{})
+	if !ok {
+		// Not a shape this check understands. Say so and let the test run
+		// rather than skipping on a guess.
+		t.Logf("could not read the hook list (%T); running anyway", result)
+		return
+	}
+
+	for _, raw := range hooks {
+		hook, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if hook["type"] == hookType {
+			t.Skipf("this tenant already has a %s hook, and it is a singleton: the API refuses a second one with a 409", hookType)
+		}
+	}
+}
 
 func TestAccSmartHook_crud(t *testing.T) {
 	base := GetFixture("onelogin_smarthooks_example.tf", t)
 	update := GetFixture("onelogin_smarthooks_updated_example.tf", t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
+		PreCheck: func() {
+			TestAccPreCheck(t)
+			skipIfHookTypeExists(t, "pre-authentication")
+		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/onelogin/resource_onelogin_user_custom_attributes_test.go
+++ b/onelogin/resource_onelogin_user_custom_attributes_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -168,28 +169,33 @@ func TestUserCustomAttributeDefinitionUpdateInput(t *testing.T) {
 }
 
 func TestAccUserCustomAttributes_basic(t *testing.T) {
+	// Inline rather than a fixture, so the token is substituted here. Custom
+	// attribute shortnames are unique per tenant, and a definition left behind
+	// by an earlier run would otherwise collide.
+	suffix := acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { TestAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckUserCustomAttributesConfig(),
+				Config: testAccCheckUserCustomAttributesConfig(suffix),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("onelogin_user_custom_attributes.test_attr", "name", "Test Attribute"),
-					resource.TestCheckResourceAttr("onelogin_user_custom_attributes.test_attr", "shortname", "test_attr"),
+					resource.TestCheckResourceAttr("onelogin_user_custom_attributes.test_attr", "shortname", "test_attr_"+suffix),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckUserCustomAttributesConfig() string {
-	return `
+func testAccCheckUserCustomAttributesConfig(suffix string) string {
+	return strings.ReplaceAll(`
 resource onelogin_user_custom_attributes test_attr {
   name      = "Test Attribute"
-  shortname = "test_attr"
+  shortname = "test_attr_acctest"
 }
-`
+`, fixtureUniqueToken, suffix)
 }
 
 // TestAccUserCustomAttributes_position walks a definition through the lifecycle
@@ -238,16 +244,20 @@ resource onelogin_user_custom_attributes positioned_attr {
 }
 
 func TestAccUserCustomAttributesWithUser_basic(t *testing.T) {
+	// This config is inline rather than a fixture, so it needs the token
+	// substituted here: OneLogin enforces unique usernames per tenant.
+	suffix := acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { TestAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckUserCustomAttributesWithUserConfig(),
+				Config: testAccCheckUserCustomAttributesWithUserConfig(suffix),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("onelogin_users.test_user", "username", "test.user.for.attrs"),
+					resource.TestCheckResourceAttrSet("onelogin_users.test_user", "username"),
 					resource.TestCheckResourceAttr("onelogin_user_custom_attributes.test_attr", "name", "Test Attribute"),
-					resource.TestCheckResourceAttr("onelogin_user_custom_attributes.test_attr", "shortname", "test_attr"),
+					resource.TestCheckResourceAttr("onelogin_user_custom_attributes.test_attr", "shortname", "test_attr_"+suffix),
 					resource.TestCheckResourceAttrSet("onelogin_user_custom_attributes.user_attr_value", "user_id"),
 					resource.TestCheckResourceAttr("onelogin_user_custom_attributes.user_attr_value", "value", "test_value"),
 				),
@@ -256,16 +266,16 @@ func TestAccUserCustomAttributesWithUser_basic(t *testing.T) {
 	})
 }
 
-func testAccCheckUserCustomAttributesWithUserConfig() string {
-	return `
+func testAccCheckUserCustomAttributesWithUserConfig(suffix string) string {
+	return strings.ReplaceAll(`
 resource onelogin_users test_user {
-  username = "test.user.for.attrs"
-  email    = "test.user.attrs@example.com"
+  username = "test.user.for.attrs.acctest"
+  email    = "test.user.attrs.acctest@example.com"
 }
 
 resource onelogin_user_custom_attributes test_attr {
   name      = "Test Attribute"
-  shortname = "test_attr"
+  shortname = "test_attr_acctest"
 }
 
 resource onelogin_user_custom_attributes user_attr_value {
@@ -273,5 +283,5 @@ resource onelogin_user_custom_attributes user_attr_value {
   shortname = onelogin_user_custom_attributes.test_attr.shortname
   value     = "test_value"
 }
-`
+`, fixtureUniqueToken, suffix)
 }

--- a/onelogin/resource_onelogin_user_mappings.go
+++ b/onelogin/resource_onelogin_user_mappings.go
@@ -108,6 +108,16 @@ func userMappingRead(ctx context.Context, d *schema.ResourceData, m interface{})
 
 	result, err := client.GetUserMapping(mid32)
 	if err != nil {
+		// A mapping deleted outside Terraform is not an error to report, it is
+		// a resource to forget. Without this a plan fails outright instead of
+		// proposing to recreate it, and a destroy cannot finish at all.
+		if utils.IsNotFoundError(err) {
+			tflog.Info(ctx, "[NOT FOUND] User mapping not found, removing from state", map[string]interface{}{
+				"id": mid,
+			})
+			d.SetId("")
+			return nil
+		}
 		return utils.HandleAPIError(ctx, err, utils.ErrorCategoryRead, "User Mapping", d.Id())
 	}
 
@@ -212,8 +222,10 @@ func userMappingDelete(ctx context.Context, d *schema.ResourceData, m interface{
 		"id": mid,
 	})
 
-	err := client.DeleteUserMapping(mid32)
-	if err != nil {
+	// A 404 is the state the delete was asking for, so it falls through to the
+	// same ending as a successful one. Reporting it would leave the mapping in
+	// state for the next run to fail on again.
+	if err := client.DeleteUserMapping(mid32); err != nil && !utils.IsNotFoundError(err) {
 		return utils.HandleAPIError(ctx, err, utils.ErrorCategoryDelete, "User Mapping", d.Id())
 	}
 

--- a/onelogin/resource_onelogin_user_mappings_test.go
+++ b/onelogin/resource_onelogin_user_mappings_test.go
@@ -8,8 +8,15 @@ import (
 )
 
 func TestAccUserMapping_crud(t *testing.T) {
-	base := GetFixture("onelogin_user_mapping_example.tf", t)
-	update := GetFixture("onelogin_user_mapping_updated_example.tf", t)
+	// The fixtures were rewritten as fuller documentation at some point and
+	// these assertions were never updated with them: they described a
+	// "basic_test" mapping the files have not defined for years. Nothing
+	// noticed, because the suite could not run.
+	fixtures := GetFixtures([]string{
+		"onelogin_user_mapping_example.tf",
+		"onelogin_user_mapping_updated_example.tf",
+	}, t)
+	base, update := fixtures[0], fixtures[1]
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { TestAccPreCheck(t) },
@@ -18,25 +25,22 @@ func TestAccUserMapping_crud(t *testing.T) {
 			{
 				Config: base,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("onelogin_user_mappings.basic_test", "name", "Select Login"),
-					resource.TestCheckResourceAttr("onelogin_user_mappings.basic_test", "enabled", "true"),
-					resource.TestCheckResourceAttr("onelogin_user_mappings.basic_test", "match", "all"),
-					resource.TestCheckResourceAttr("onelogin_user_mappings.basic_test", "actions.0.action", "set_status"),
-					resource.TestCheckResourceAttr("onelogin_user_mappings.basic_test", "conditions.0.value", "90"),
-					resource.TestCheckResourceAttr("onelogin_user_mappings.basic_test", "conditions.0.source", "last_login"),
-					resource.TestCheckResourceAttr("onelogin_user_mappings.basic_test", "conditions.0.operator", ">"),
+					resource.TestCheckResourceAttr("onelogin_user_mappings.example_mapping", "name", "Example Domain Mapping"),
+					resource.TestCheckResourceAttr("onelogin_user_mappings.example_mapping", "enabled", "true"),
+					resource.TestCheckResourceAttr("onelogin_user_mappings.example_mapping", "match", "all"),
+					resource.TestCheckResourceAttr("onelogin_user_mappings.example_mapping", "conditions.0.source", "email"),
+					resource.TestCheckResourceAttr("onelogin_user_mappings.example_mapping", "conditions.0.operator", "~"),
+					resource.TestCheckResourceAttr("onelogin_user_mappings.example_mapping", "actions.0.action", "add_role"),
+					resource.TestCheckResourceAttr("onelogin_user_mappings.department_mapping", "name", "Department Based Mapping"),
 				),
 			},
 			{
 				Config: update,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("onelogin_user_mappings.basic_test", "name", "Updated Login"),
-					resource.TestCheckResourceAttr("onelogin_user_mappings.basic_test", "enabled", "true"),
-					resource.TestCheckResourceAttr("onelogin_user_mappings.basic_test", "match", "all"),
-					resource.TestCheckResourceAttr("onelogin_user_mappings.basic_test", "actions.0.action", "set_status"),
-					resource.TestCheckResourceAttr("onelogin_user_mappings.basic_test", "conditions.0.value", "120"),
-					resource.TestCheckResourceAttr("onelogin_user_mappings.basic_test", "conditions.0.source", "last_login"),
-					resource.TestCheckResourceAttr("onelogin_user_mappings.basic_test", "conditions.0.operator", ">"),
+					resource.TestCheckResourceAttr("onelogin_user_mappings.example_mapping", "name", "Updated Domain Mapping"),
+					resource.TestCheckResourceAttr("onelogin_user_mappings.example_mapping", "enabled", "true"),
+					resource.TestCheckResourceAttr("onelogin_user_mappings.example_mapping", "match", "all"),
+					resource.TestCheckResourceAttr("onelogin_user_mappings.department_mapping", "name", "Engineering Team Mapping"),
 				),
 			},
 		},

--- a/onelogin/resource_onelogin_user_mappings_test.go
+++ b/onelogin/resource_onelogin_user_mappings_test.go
@@ -39,8 +39,16 @@ func TestAccUserMapping_crud(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("onelogin_user_mappings.example_mapping", "name", "Updated Domain Mapping"),
 					resource.TestCheckResourceAttr("onelogin_user_mappings.example_mapping", "enabled", "true"),
-					resource.TestCheckResourceAttr("onelogin_user_mappings.example_mapping", "match", "all"),
+					// "any", not "all". Switching the two is what the updated
+					// fixture is demonstrating, and the assertion had been
+					// asserting that the change did not happen.
+					resource.TestCheckResourceAttr("onelogin_user_mappings.example_mapping", "match", "any"),
+					resource.TestCheckResourceAttr("onelogin_user_mappings.example_mapping", "conditions.#", "2"),
+					resource.TestCheckResourceAttr("onelogin_user_mappings.example_mapping", "actions.1.action", "set_userprincipalname"),
 					resource.TestCheckResourceAttr("onelogin_user_mappings.department_mapping", "name", "Engineering Team Mapping"),
+					// One role per action: the API rejects two values in a
+					// single add_role.
+					resource.TestCheckResourceAttr("onelogin_user_mappings.department_mapping", "actions.#", "2"),
 				),
 			},
 		},

--- a/onelogin/resource_onelogin_users_test.go
+++ b/onelogin/resource_onelogin_users_test.go
@@ -7,8 +7,14 @@ import (
 )
 
 func TestAccUser_crud(t *testing.T) {
-	base := GetFixture("onelogin_user_example.tf", t)
-	update := GetFixture("onelogin_user_updated_example.tf", t)
+	// One suffix across both steps, and known here so the assertions can
+	// include it: the fixtures carry a per-run token because OneLogin enforces
+	// unique usernames and emails within a tenant.
+	fixtures, suffix := GetFixturesWithSuffix([]string{
+		"onelogin_user_example.tf",
+		"onelogin_user_updated_example.tf",
+	}, t)
+	base, update := fixtures[0], fixtures[1]
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { TestAccPreCheck(t) },
@@ -17,15 +23,15 @@ func TestAccUser_crud(t *testing.T) {
 			{
 				Config: base,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("onelogin_users.basic_test", "username", "testy.mctesterson"),
-					resource.TestCheckResourceAttr("onelogin_users.basic_test", "email", "testy.mctesterson@onelogin.com"),
+					resource.TestCheckResourceAttr("onelogin_users.basic_test", "username", "testy.mctesterson."+suffix),
+					resource.TestCheckResourceAttr("onelogin_users.basic_test", "email", "testy.mctesterson."+suffix+"@example.com"),
 				),
 			},
 			{
 				Config: update,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("onelogin_users.basic_test", "username", "boaty.mcboatface"),
-					resource.TestCheckResourceAttr("onelogin_users.basic_test", "email", "boaty.mcboatface@onelogin.com"),
+					resource.TestCheckResourceAttr("onelogin_users.basic_test", "username", "boaty.mcboatface."+suffix),
+					resource.TestCheckResourceAttr("onelogin_users.basic_test", "email", "boaty.mcboatface."+suffix+"@example.com"),
 				),
 			},
 		},
@@ -33,8 +39,11 @@ func TestAccUser_crud(t *testing.T) {
 }
 
 func TestAccUser_trustedIdp(t *testing.T) {
-	withIdp := GetFixture("onelogin_user_with_trusted_idp_example.tf", t)
-	withoutIdp := GetFixture("onelogin_user_without_trusted_idp_example.tf", t)
+	fixtures, suffix := GetFixturesWithSuffix([]string{
+		"onelogin_user_with_trusted_idp_example.tf",
+		"onelogin_user_without_trusted_idp_example.tf",
+	}, t)
+	withIdp, withoutIdp := fixtures[0], fixtures[1]
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { TestAccPreCheck(t) },
@@ -43,17 +52,23 @@ func TestAccUser_trustedIdp(t *testing.T) {
 			{
 				Config: withIdp,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("onelogin_users.trusted_idp_test", "username", "trusted.idp.test"),
-					resource.TestCheckResourceAttr("onelogin_users.trusted_idp_test", "email", "trusted.idp.test@onelogin.com"),
+					resource.TestCheckResourceAttr("onelogin_users.trusted_idp_test", "username", "trusted.idp.test."+suffix),
+					resource.TestCheckResourceAttr("onelogin_users.trusted_idp_test", "email", "trusted.idp.test."+suffix+"@example.com"),
 					resource.TestCheckResourceAttr("onelogin_users.trusted_idp_test", "trusted_idp_id", "123456"),
 				),
 			},
 			{
 				Config: withoutIdp,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("onelogin_users.trusted_idp_test", "username", "trusted.idp.test"),
-					resource.TestCheckResourceAttr("onelogin_users.trusted_idp_test", "email", "trusted.idp.test@onelogin.com"),
-					resource.TestCheckNoResourceAttr("onelogin_users.trusted_idp_test", "trusted_idp_id"),
+					resource.TestCheckResourceAttr("onelogin_users.trusted_idp_test", "username", "trusted.idp.test."+suffix),
+					resource.TestCheckResourceAttr("onelogin_users.trusted_idp_test", "email", "trusted.idp.test."+suffix+"@example.com"),
+					// trusted_idp_id is Optional and Computed, so dropping it
+					// from the configuration means "keep whatever the API has"
+					// rather than "clear it" — Terraform cannot tell an omitted
+					// Computed attribute from an unset one. The old assertion
+					// of absence could never have held. Clearing it needs an
+					// explicit 0.
+					resource.TestCheckResourceAttr("onelogin_users.trusted_idp_test", "trusted_idp_id", "123456"),
 				),
 			},
 		},

--- a/onelogin/tf_test_fixture.go
+++ b/onelogin/tf_test_fixture.go
@@ -29,6 +29,19 @@ func GetFixture(name string, t *testing.T) string {
 	return getFixtureWithSuffix(name, acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum), t)
 }
 
+// GetFixturesWithSuffix returns several fixtures sharing one suffix, and the
+// suffix itself, for tests that assert on a value the token appears in.
+func GetFixturesWithSuffix(names []string, t *testing.T) ([]string, string) {
+	t.Helper()
+	suffix := acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum)
+
+	out := make([]string, 0, len(names))
+	for _, name := range names {
+		out = append(out, getFixtureWithSuffix(name, suffix, t))
+	}
+	return out, suffix
+}
+
 // GetFixtures returns several fixtures sharing one suffix, for a test whose
 // steps must refer to the same resources. Loading them separately would give
 // each step a different suffix, and the second step would replace every
@@ -55,5 +68,41 @@ func getFixtureWithSuffix(name, suffix string, t *testing.T) string {
 		t.Fatalf("failed to load fixture %s for acceptance test: %v", name, err)
 	}
 
-	return strings.ReplaceAll(string(rawFile), fixtureUniqueToken, suffix)
+	return stripProviderConfig(strings.ReplaceAll(string(rawFile), fixtureUniqueToken, suffix))
+}
+
+// stripProviderConfig removes terraform{} and provider{} blocks from a fixture.
+//
+// They belong in examples/ — a reader copying one needs to know which provider
+// it wants — but an acceptance test is given the provider under test, and a
+// required_providers block asking the registry for a version makes Terraform
+// try to resolve it instead:
+//
+//	Error: Inconsistent dependency lock file
+//	  provider registry.terraform.io/onelogin/onelogin: required by this
+//	  configuration but no version is selected
+func stripProviderConfig(config string) string {
+	var out strings.Builder
+	depth, skipping := 0, false
+
+	for _, line := range strings.Split(config, "\n") {
+		trimmed := strings.TrimSpace(line)
+
+		if !skipping && (strings.HasPrefix(trimmed, "terraform {") || strings.HasPrefix(trimmed, "provider ")) {
+			skipping = true
+			depth = 0
+		}
+		if !skipping {
+			out.WriteString(line + "\n")
+			continue
+		}
+
+		// Counting braces rather than looking for a closing line on its own:
+		// these blocks nest, and required_providers is two deep.
+		depth += strings.Count(line, "{") - strings.Count(line, "}")
+		if depth <= 0 {
+			skipping = false
+		}
+	}
+	return out.String()
 }

--- a/onelogin/tf_test_fixture.go
+++ b/onelogin/tf_test_fixture.go
@@ -88,7 +88,11 @@ func stripProviderConfig(config string) string {
 	for _, line := range strings.Split(config, "\n") {
 		trimmed := strings.TrimSpace(line)
 
-		if !skipping && (strings.HasPrefix(trimmed, "terraform {") || strings.HasPrefix(trimmed, "provider ")) {
+		// `provider "` rather than `provider `: the latter also matches the
+		// provider meta-argument inside a resource, `provider = onelogin.eu`,
+		// and would silently drop that line and the resource's provider with
+		// it. A provider block always carries a quoted name.
+		if !skipping && (strings.HasPrefix(trimmed, "terraform {") || strings.HasPrefix(trimmed, "provider \"")) {
 			skipping = true
 			depth = 0
 		}

--- a/onelogin/tf_test_fixture_test.go
+++ b/onelogin/tf_test_fixture_test.go
@@ -1,0 +1,57 @@
+package onelogin
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStripProviderConfig covers what the fixture loader removes, and more
+// importantly what it must not.
+func TestStripProviderConfig(t *testing.T) {
+	t.Run("removes the blocks an acceptance test supplies itself", func(t *testing.T) {
+		out := stripProviderConfig(`terraform {
+  required_providers {
+    onelogin = {
+      source  = "onelogin/onelogin"
+      version = ">= 0.8.0"
+    }
+  }
+}
+
+provider "onelogin" {
+  # comment
+}
+
+resource onelogin_roles role {
+  name = "kept"
+}
+`)
+
+		for _, gone := range []string{"required_providers", "onelogin/onelogin", `provider "onelogin"`} {
+			if strings.Contains(out, gone) {
+				t.Fatalf("expected %q to be stripped, got:\n%s", gone, out)
+			}
+		}
+		if !strings.Contains(out, `name = "kept"`) {
+			t.Fatalf("expected the resource to survive, got:\n%s", out)
+		}
+	})
+
+	t.Run("keeps the provider meta-argument inside a resource", func(t *testing.T) {
+		// `provider = onelogin.eu` selects an aliased provider for one
+		// resource. Matching on "provider " rather than `provider "` dropped
+		// this line, quietly moving the resource to the default provider.
+		out := stripProviderConfig(`resource onelogin_roles role {
+  provider = onelogin.eu
+  name     = "kept"
+}
+`)
+
+		if !strings.Contains(out, "provider = onelogin.eu") {
+			t.Fatalf("expected the provider meta-argument to survive, got:\n%s", out)
+		}
+		if !strings.Contains(out, `name     = "kept"`) {
+			t.Fatalf("expected the rest of the resource to survive, got:\n%s", out)
+		}
+	})
+}

--- a/utils/resource_utils.go
+++ b/utils/resource_utils.go
@@ -45,8 +45,20 @@ func StandardDeleteFunc(
 		"id": id,
 	})
 
-	_, err = deleteFunc(id)
-	if err != nil {
+	if _, err = deleteFunc(id); err != nil {
+		// A 404 is the state the delete was asking for. Something else got
+		// there first -- another practitioner, a cascade, a retried request
+		// whose first attempt landed -- and reporting that as a failure leaves
+		// the resource in state, so the next run tries to delete it again and
+		// fails again. A destroy that cannot finish is the worse outcome.
+		if IsNotFoundError(err) {
+			tflog.Info(ctx, fmt.Sprintf("[DELETED] %s was already gone", resourceType), map[string]interface{}{
+				"id": id,
+			})
+			d.SetId("")
+			return nil
+		}
+
 		tflog.Error(ctx, fmt.Sprintf("[ERROR] Error deleting %s", resourceType), map[string]interface{}{
 			"id":    id,
 			"error": err,

--- a/utils/standard_delete_test.go
+++ b/utils/standard_delete_test.go
@@ -1,0 +1,68 @@
+package utils
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func deletableResource(t *testing.T, id string) *schema.ResourceData {
+	t.Helper()
+
+	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		"name": {Type: schema.TypeString, Optional: true},
+	}, map[string]interface{}{})
+	d.SetId(id)
+	return d
+}
+
+// TestStandardDeleteFuncNotFound covers a delete that finds the resource
+// already gone. That is the state the delete was asking for, and reporting it
+// as a failure leaves the resource in state for the next run to fail on again
+// -- a destroy that cannot finish.
+func TestStandardDeleteFuncNotFound(t *testing.T) {
+	t.Run("treats a 404 as done", func(t *testing.T) {
+		d := deletableResource(t, "12345")
+
+		diags := StandardDeleteFunc(context.Background(), d, func(string) (interface{}, error) {
+			return nil, errors.New("request failed with status: 404")
+		}, "Thing")
+
+		if diags.HasError() {
+			t.Fatalf("expected a 404 to be treated as deleted, got %v", diags)
+		}
+		if d.Id() != "" {
+			t.Fatalf("expected the id to be cleared, got %q", d.Id())
+		}
+	})
+
+	t.Run("still reports anything else", func(t *testing.T) {
+		d := deletableResource(t, "12345")
+
+		diags := StandardDeleteFunc(context.Background(), d, func(string) (interface{}, error) {
+			return nil, errors.New("request failed with status: 500")
+		}, "Thing")
+
+		if !diags.HasError() {
+			t.Fatal("expected a 500 to be reported")
+		}
+		if d.Id() == "" {
+			t.Fatal("expected the id to survive a failed delete: the resource is still there")
+		}
+	})
+
+	t.Run("clears the id on success", func(t *testing.T) {
+		d := deletableResource(t, "12345")
+
+		if diags := StandardDeleteFunc(context.Background(), d, func(string) (interface{}, error) {
+			return nil, nil
+		}, "Thing"); diags.HasError() {
+			t.Fatalf("expected a clean delete, got %v", diags)
+		}
+		if d.Id() != "" {
+			t.Fatalf("expected the id to be cleared, got %q", d.Id())
+		}
+	})
+}


### PR DESCRIPTION
Batched, per your preference. **Every acceptance test now passes or skips for a stated reason — up from three passing.**

```
PASS  TestAccAppRule_crud            PASS  TestAccUser_crud
PASS  TestAccAuthServer_crud         PASS  TestAccUser_trustedIdp
PASS  TestAccDataSourceOneLoginGroups  PASS  TestAccUserCustomAttributes_basic
PASS  TestAccOIDCApp_crud            PASS  TestAccUserCustomAttributes_position
PASS  TestAccOneLoginGroup_crud      PASS  TestAccUserCustomAttributesWithUser_basic
PASS  TestAccPrivilege_crud          PASS  TestAccUserMapping_crud
PASS  TestAccRole_crud               PASS  TestAccSAMLApp_crud
PASS  TestAccSmartHookEnvVar_crud    SKIP  TestAccSmartHook_crud  (singleton, see below)
```

Run twice back to back, clean both times, and the tenant is left with nothing behind.

Eight provider bugs, found by the suite #248 made runnable. **Two of them I shipped myself**, in the merged `include_amr_claims` work and in this PR's own first commit — both the same mistake, and the reason the fix below is general rather than per-key.

## A TypeMap cannot express "the API fills this in"

There is no per-key `Computed` on a map. A key in state and not in the configuration is a removal every plan proposes, and the next read puts it straight back.

The API answers with its own defaults regardless of what was sent: every OIDC app comes back with `include_amr_claims` false, and a SAML app comes back with a few dozen keys. So `configuration` could only ever converge for someone who had spelled out the entire object — and my `include_amr_claims` change made that strictly worse, because before it the flatten happened to drop everything the API defaults, by luck rather than design.

The prior state's key set **is** the practitioner's: on create it is the planned configuration, on refresh it is whatever the last apply wrote. That is what a read records now. An empty prior state is an import, where the whole object is written because there is no configuration to respect yet.

## Parameters, wrong in two independent ways

**Set identity.** Every attribute but `param_key_name` is Computed. A parameter whose `values` are not yet known hashes to something Terraform cannot match against the element already in state, so the plan proposed replacing the whole set. The set is now keyed on `param_key_name` — the API's own identity for a parameter, since it returns them as an object keyed by it — which is knowable from the configuration alone. The Computed attributes are then compared one at a time, which is what `Optional+Computed` is for.

**Connector parameters.** A connector brings its own: the AWS connector adds `saml_username`, `Role` and `RoleSessionName`. They are in no configuration, and the app `PUT` merges rather than replaces, so every proposed removal came straight back. A read records only the parameters the configuration has.

## An environment variable could never be updated

The endpoint takes the ID from the URL and refuses a body carrying anything else:

```
422 instance is not allowed to have the additional property "id"
```

The provider sent the id, so **every** update of a `onelogin_smarthook_environment_variables` failed. `name` is `ForceNew` now — the API refuses a name in the body too, so a rename could only ever have been silently dropped.

## Privilege statements come back in an arbitrary order

`statement` is a `TypeList`, where order is part of the value, and the API does not preserve it — the same privilege comes back with its statements swapped from one read to the next. A read now restores the order already in state, matching statements on their contents rather than their position.

This is what made `TestAccPrivilege_crud` fail about every other run. I had put that down to test isolation on a shared tenant, in this PR's own description. It wasn't; running it twice in a row shows it.

## Two tests that could not have caught anything

- `TestLogicalImplementation` passed the read a **nil** meta, which guarantees the panic it was written to catch — every read opens with `m.(*onelogin.OneloginSDK)`. It went unnoticed because the body only runs once something else has configured the provider: alone it skipped and passed, after any acceptance test it failed. Terraform never calls a read with a nil meta.
- The SAML parameter check built the regex `parameters\.\d+\.param_key_name\s*=\s*email` and matched it against the attribute **key**, which is only ever an address. It matched nothing, so no parameter was ever found — while the value comparison that would have worked sat right beside it, unreached.

## Fixture rot

Confirmed against the API rather than guessed:

| | |
| --- | --- |
| `add_role` | takes **one** value; two IDs are rejected as `Invalid action value(s): <both>`, naming the values when the fault is the count |
| role IDs | `12345`, `340475`, `34567` … exist on no tenant — the mapping and app-rule fixtures now create the roles they reference |
| operators | words; the API takes `~`, `=`, `bw`, `ew`, and `ri`/`rin` for `has_role` |
| actions | `set_role` is `add_role`; `set_groups` and `set_custom_attribute` are not actions |
| `position` | required on a mapping update, and bounded by how many mappings the tenant already has |
| runtimes | `nodejs12.x` → `nodejs22.x`; the API now takes only 22 and 24 |
| group `reference` | accepted, then neither stored nor returned |
| block syntax | `configuration = { … }` has been invalid since Terraform 0.12 — those fixtures had not parsed since 2019 |

Fixing the block syntax exposed why nobody had noticed: `Inflate` asserted `map[string]interface{}` on a `TypeSet`, which hands over a `*schema.Set`. **Setting the block would have panicked the provider.** `MaxItems: 1` now makes the single-element assumption real, and a test builds an actual set.

Identities also carry a per-run token and moved off `@onelogin.com`, a real domain we should not be inventing addresses in.

Two test *expectations* were wrong rather than the code: the mapping assertions described a `basic_test` resource the fixtures have not defined in years and asserted `match` stayed `"all"` when switching it to `"any"` is the point of the updated fixture; and `TestAccUser_trustedIdp` expected `trusted_idp_id` to vanish when dropped from configuration, though it is `Optional` **and** `Computed`.

## The one skip

`TestAccSmartHook_crud` skips where the tenant already has a pre-authentication hook:

```
409 The 'pre-authentication' hook is synchronous and can only have one defined function
```

The alternative is deleting whatever is there, and on a shared tenant that is somebody's live authentication path. The skip says so, and the check is a real API call, so it runs wherever it can.

## Also worth flagging

- **`reference` on a group could not be used at all.** The API accepts it, does not store it, and returns null — and the read wrote that null back over whatever the configuration had asked for. It is left alone now, so a configuration that uses the attribute settles. Import is the one case that cannot work, since there is no prior state to preserve it from; `ImportStateVerify` ignores it and says why. Copilot found this by noticing the assertion I had left behind for it was checking `name`.
- The groups data source has **never** worked: `GetGroups` calls `api/1/groups`, which wraps its payload in `{"status":…,"data":[…]}`, and the read asserted a bare slice. It accepts either shape now.
- Zero is a real value for `oidc_application_type` (Web) and `token_endpoint_auth_method` (basic). Both were skipped as unset, so the commonest OIDC configuration never reached state. Three unit tests asserted the old behaviour, one commented `// oidc_application_type is 0, which Flatten drops as a zero value` — the bug written down as an expectation.
- `TestAccPreCheck` accepted a bare `ONELOGIN_SUBDOMAIN`, logging that it was deprecated — which reads as though the older setting still works. It does not work at all: the provider's `url` is `Required`, so such a run gets past the check and then fails every step with `The argument "url" is required`. The check now requires `ONELOGIN_API_URL` and says why. (Copilot suggested the opposite — falling back to the subdomain — but the premise that the provider can be configured that way does not hold, and the fallback would have made the precheck the one thing in a run to contact `<subdomain>.onelogin.com`, i.e. production.)
- `subdomainFromURL` is lifted out of `configProvider` so the smarthook precheck can use it rather than restating it, and it now rejects an empty subdomain instead of silently accepting one.

## A flake I have reduced but cannot claim to have fixed

`TestAccUserMapping_crud` failed about **one run in twelve**, always on the post-test destroy, always `request failed with status: 404`. Twenty instrumented runs did not reproduce it, so I cannot say what removes the mapping first.

What turns that into a *failure* is the provider, and that part is wrong regardless of the trigger. A delete that finds the resource already gone has got what it asked for; reporting it leaves the resource in state, so the next run tries again and fails the same way — a destroy that can never finish. `StandardDeleteFunc` now treats it as done, covering apps, OIDC apps, SAML apps, users, roles, groups and self-registration profiles in one place. User mappings do not use that helper and were wrong in both directions: **a mapping deleted in the OneLogin UI made every plan fail outright** instead of proposing to recreate it.

Fifteen consecutive runs are clean since. At an ~8% failure rate that is weak evidence on its own, and I would rather say so than call it fixed. The argument for the change is that the old behaviour was wrong.

## Testing

- `make test`, `go build`, `go vet`, `gofmt` clean. CI unaffected — it runs `-short`.
- Full suite run twice consecutively against a live development tenant; every new behaviour also has unit coverage that runs without one.


