### PR TITLE
AB#000: privilege action and scope order

### DIFF
--- a/examples/onelogin_privilege_example.tf
+++ b/examples/onelogin_privilege_example.tf
@@ -27,9 +27,10 @@ resource onelogin_privileges super_admin {
 		action = ["apps:List"]
 		scope = ["*"]
 	}
+	# A statement may grant several actions over the same scope.
 	statement {
 		effect = "Allow"
-		action = ["users:List"]
+		action = ["users:List", "users:Get", "users:Update", "users:Delete"]
 		scope = ["*"]
 	}
   }

--- a/examples/onelogin_privilege_updated_example.tf
+++ b/examples/onelogin_privilege_updated_example.tf
@@ -27,9 +27,10 @@ resource onelogin_privileges super_admin {
 		action = ["apps:List"]
 		scope = ["*"]
 	}
+	# A statement may grant several actions over the same scope.
 	statement {
 		effect = "Allow"
-		action = ["users:List"]
+		action = ["users:List", "users:Get", "users:Update", "users:Delete"]
 		scope = ["*"]
 	}
   }

--- a/ol_schema/privilege/privilege.go
+++ b/ol_schema/privilege/privilege.go
@@ -49,7 +49,7 @@ func OrderStatementsLikeState(prior interface{}, statements []map[string]interfa
 		for i, statement := range statements {
 			if !used[i] && statementKey(statement) == key {
 				used[i] = true
-				out = append(out, statement)
+				out = append(out, orderValuesLikeState(priorStatement, statement))
 				break
 			}
 		}
@@ -99,37 +99,104 @@ func statementsFromState(prior interface{}) []map[string]interface{} {
 	return out
 }
 
-// statementKey identifies a statement by its contents. The action and scope
-// lists are sorted for the comparison only -- the values written to state are
-// the ones the API returned, untouched.
+// orderValuesLikeState puts the action and scope values of a matched statement
+// back into the order the configuration has them in.
 //
-// Untouched is safe: unlike the statements themselves, the API preserves the
-// order of the values inside one. A statement created with
-// ["users:List","users:Get","users:Update","users:Delete"] comes back in that
-// order on every read. Sorting here just means a statement is still recognised
-// if that ever stops being true.
+// The API does not preserve the order of the values inside a statement any more
+// than it preserves the order of the statements themselves: a statement written
+// as ["users:List","users:Get"] can be read back as ["users:Get","users:List"].
+// action and scope are TypeLists, so that is a changed value, and because
+// privilege is a TypeSet the changed value changes the element's hash -- which
+// is why the plan proposes removing the whole privilege block and adding it
+// back rather than editing it in place.
+//
+// Only values the prior statement already has are moved, and every value the
+// API returned is kept, so this reorders without ever inventing or dropping
+// one. A matched statement is copied rather than edited in place, so the
+// caller's map is left as it was. Statements that match nothing are passed
+// through as they arrived, and are the caller's own maps.
+func orderValuesLikeState(prior, statement map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(statement))
+	for key, value := range statement {
+		out[key] = value
+	}
+
+	for _, field := range []string{"action", "scope"} {
+		// A field the response did not give us as a list is left exactly as it
+		// arrived, rather than becoming an empty one. The test is the same one
+		// statementKey uses, so a statement can never match on its contents and
+		// then quietly skip the reordering -- that would be a perpetual diff
+		// with nothing to show for it.
+		values, ok := toStrings(statement[field])
+		if !ok {
+			continue
+		}
+		priorValues, _ := toStrings(prior[field])
+		out[field] = orderLikePrior(priorValues, values)
+	}
+	return out
+}
+
+// orderLikePrior returns returned, with the values prior names first and in
+// prior's order, then anything left over in the order the API gave it.
+func orderLikePrior(prior, returned []string) []interface{} {
+	used := make([]bool, len(returned))
+	out := make([]interface{}, 0, len(returned))
+
+	for _, want := range prior {
+		for i, got := range returned {
+			if !used[i] && got == want {
+				used[i] = true
+				out = append(out, got)
+				break
+			}
+		}
+	}
+
+	for i, got := range returned {
+		if !used[i] {
+			out = append(out, got)
+		}
+	}
+	return out
+}
+
+// statementKey identifies a statement by its contents. The action and scope
+// lists are sorted so that a statement is recognised as the same statement
+// however the API happens to have ordered its values; orderValuesLikeState then
+// restores the configuration's order in the value that reaches state.
+//
+// The separators are NUL so that a value containing one cannot forge a key:
+// joined on ",", ["a,b"] and ["a","b"] both render as "a,b" and compare equal.
+// No OneLogin action or scope contains a NUL.
 func statementKey(statement map[string]interface{}) string {
 	parts := []string{fmt.Sprint(statement["effect"])}
 
 	for _, field := range []string{"action", "scope"} {
-		values := toStrings(statement[field])
+		values, _ := toStrings(statement[field])
 		sort.Strings(values)
-		parts = append(parts, strings.Join(values, ","))
+		parts = append(parts, strings.Join(values, "\x00"))
 	}
-	return strings.Join(parts, "|")
+	return strings.Join(parts, "\x00|\x00")
 }
 
-func toStrings(value interface{}) []string {
-	items, ok := value.([]interface{})
-	if !ok {
-		return nil
+// toStrings reads the two shapes a statement's values arrive in: []interface{}
+// from a decoded API response, and []string from FlattenPrivilegeData. It
+// reports whether the value was one of them, so that callers can tell an empty
+// list from something that is not a list at all -- keying those the same would
+// make any two statements sharing an effect look identical.
+func toStrings(value interface{}) ([]string, bool) {
+	switch items := value.(type) {
+	case []interface{}:
+		out := make([]string, 0, len(items))
+		for _, item := range items {
+			out = append(out, fmt.Sprint(item))
+		}
+		return out, true
+	case []string:
+		return append([]string(nil), items...), true
 	}
-
-	out := make([]string, 0, len(items))
-	for _, item := range items {
-		out = append(out, fmt.Sprint(item))
-	}
-	return out
+	return nil, false
 }
 
 func Schema() map[string]*schema.Schema {

--- a/ol_schema/privilege/privilege.go
+++ b/ol_schema/privilege/privilege.go
@@ -173,9 +173,18 @@ func statementKey(statement map[string]interface{}) string {
 	parts := []string{fmt.Sprint(statement["effect"])}
 
 	for _, field := range []string{"action", "scope"} {
-		values, _ := toStrings(statement[field])
+		values, ok := toStrings(statement[field])
+		if !ok {
+			// Not a list at all. Keyed distinctly from an empty list, and by
+			// what it actually was, so two statements that merely both have an
+			// unreadable field cannot match each other and get paired up. The
+			// "L"/"X" prefix keeps the two cases from ever colliding, whatever
+			// the values happen to contain.
+			parts = append(parts, "X"+fmt.Sprint(statement[field]))
+			continue
+		}
 		sort.Strings(values)
-		parts = append(parts, strings.Join(values, "\x00"))
+		parts = append(parts, "L"+strings.Join(values, "\x00"))
 	}
 	return strings.Join(parts, "\x00|\x00")
 }

--- a/ol_schema/privilege/statement_order_test.go
+++ b/ol_schema/privilege/statement_order_test.go
@@ -165,6 +165,28 @@ func TestOrderStatementsLikeState(t *testing.T) {
 		}
 	})
 
+	t.Run("an unreadable field is not the same as an empty one", func(t *testing.T) {
+		// action and scope are Required, so neither case should reach us. If
+		// one does, keying them alike would let two statements that have
+		// nothing in common match on their shared effect and be paired up.
+		missing := map[string]interface{}{"effect": "Allow", "scope": []interface{}{"*"}}
+		empty := map[string]interface{}{"effect": "Allow", "action": []interface{}{}, "scope": []interface{}{"*"}}
+		text := map[string]interface{}{"effect": "Allow", "action": "users:List", "scope": []interface{}{"*"}}
+
+		keys := map[string]string{
+			"missing action":  statementKey(missing),
+			"empty action":    statementKey(empty),
+			"action a string": statementKey(text),
+		}
+		seen := map[string]string{}
+		for name, key := range keys {
+			if other, clash := seen[key]; clash {
+				t.Fatalf("%s and %s share a statement key", name, other)
+			}
+			seen[key] = name
+		}
+	})
+
 	t.Run("does not mutate the response it was given", func(t *testing.T) {
 		configured := statement("Allow", "users:List", "users:Get")
 		returned := statement("Allow", "users:Get", "users:List")

--- a/ol_schema/privilege/statement_order_test.go
+++ b/ol_schema/privilege/statement_order_test.go
@@ -18,6 +18,37 @@ func statement(effect string, actions ...string) map[string]interface{} {
 	}
 }
 
+// TestOrderLikePrior covers the value reordering on its own, including the
+// leftover branch that OrderStatementsLikeState cannot reach: a matched
+// statement always has the same set of values, so the branch is defensive.
+func TestOrderLikePrior(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		prior    []string
+		returned []string
+		want     []string
+	}{
+		{"restores order", []string{"b", "a"}, []string{"a", "b"}, []string{"b", "a"}},
+		{"already in order", []string{"a", "b"}, []string{"a", "b"}, []string{"a", "b"}},
+		{"unknown values keep API order", []string{"b"}, []string{"c", "a", "b"}, []string{"b", "c", "a"}},
+		{"prior names values that are gone", []string{"x", "a"}, []string{"a"}, []string{"a"}},
+		{"no prior", nil, []string{"b", "a"}, []string{"b", "a"}},
+		{"duplicates survive", []string{"a", "b"}, []string{"b", "a", "a"}, []string{"a", "b", "a"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := orderLikePrior(tc.prior, tc.returned)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Fatalf("got %v, want %v", got, tc.want)
+				}
+			}
+		})
+	}
+}
+
 // priorPrivilege builds the value d.Get("privilege") returns: a set of one
 // document holding the statements in the order the configuration has them.
 func priorPrivilege(statements ...map[string]interface{}) *schema.Set {
@@ -62,9 +93,8 @@ func TestOrderStatementsLikeState(t *testing.T) {
 	})
 
 	t.Run("matches on contents, not position", func(t *testing.T) {
-		// Same statement, actions listed the other way round. Order within a
-		// statement's action list is the practitioner's, so it is compared
-		// order-insensitively but written back untouched.
+		// Same statement, actions listed the other way round. It is still the
+		// same statement, and the configuration's order is what reaches state.
 		configured := statement("Allow", "apps:List", "users:List")
 		returned := statement("Allow", "users:List", "apps:List")
 
@@ -73,8 +103,76 @@ func TestOrderStatementsLikeState(t *testing.T) {
 		if len(out) != 1 {
 			t.Fatalf("expected the statement to be matched, got %v", out)
 		}
-		if actions := out[0]["action"].([]interface{}); actions[0] != "users:List" {
-			t.Fatalf("expected the API's own values to be written back, got %v", actions)
+		if actions := out[0]["action"].([]interface{}); actions[0] != "apps:List" {
+			t.Fatalf("expected the configuration's order, got %v", actions)
+		}
+	})
+
+	t.Run("restores the order of the values inside a statement", func(t *testing.T) {
+		// gh-254: the API reorders the values within a statement too, and
+		// action is a TypeList inside a TypeSet, so a swapped pair changes the
+		// privilege element's hash and every plan proposes replacing the block.
+		configured := statement("Allow", "users:List", "users:Get")
+		returned := statement("Allow", "users:Get", "users:List")
+		returned["scope"] = []interface{}{"users/2", "users/1"}
+		configured["scope"] = []interface{}{"users/1", "users/2"}
+
+		out := OrderStatementsLikeState(priorPrivilege(configured), []map[string]interface{}{returned})
+
+		if got := out[0]["action"].([]interface{}); got[0] != "users:List" || got[1] != "users:Get" {
+			t.Fatalf("expected the configuration's action order, got %v", got)
+		}
+		if got := out[0]["scope"].([]interface{}); got[0] != "users/1" || got[1] != "users/2" {
+			t.Fatalf("expected the configuration's scope order, got %v", got)
+		}
+	})
+
+	t.Run("a different set of actions is a different statement", func(t *testing.T) {
+		// statementKey covers the whole action set, so reordering only ever
+		// applies to statements that are genuinely the same one. A statement
+		// that gained an action does not match, and keeps what the API sent --
+		// the reordering can never mask a real change.
+		configured := statement("Allow", "users:List")
+		returned := statement("Allow", "users:Get", "users:List")
+
+		out := OrderStatementsLikeState(priorPrivilege(configured), []map[string]interface{}{returned})
+
+		if got := out[0]["action"].([]interface{}); got[0] != "users:Get" || len(got) != 2 {
+			t.Fatalf("expected the API's statement untouched, got %v", got)
+		}
+	})
+
+	t.Run("reorders a statement whose values are []string", func(t *testing.T) {
+		// FlattenPrivilegeData builds the values as []string rather than
+		// []interface{}. statementKey reads both, so orderValuesLikeState must
+		// too -- a statement that matches on its contents and is then skipped
+		// would be the perpetual diff all over again, with nothing logged.
+		configured := statement("Allow", "users:List", "users:Get")
+		returned := map[string]interface{}{
+			"effect": "Allow",
+			"action": []string{"users:Get", "users:List"},
+			"scope":  []string{"*"},
+		}
+
+		out := OrderStatementsLikeState(priorPrivilege(configured), []map[string]interface{}{returned})
+
+		got, ok := toStrings(out[0]["action"])
+		if !ok {
+			t.Fatalf("action was not a list of values: %#v", out[0]["action"])
+		}
+		if got[0] != "users:List" || got[1] != "users:Get" {
+			t.Fatalf("expected the configuration's order, got %v", got)
+		}
+	})
+
+	t.Run("does not mutate the response it was given", func(t *testing.T) {
+		configured := statement("Allow", "users:List", "users:Get")
+		returned := statement("Allow", "users:Get", "users:List")
+
+		OrderStatementsLikeState(priorPrivilege(configured), []map[string]interface{}{returned})
+
+		if got := returned["action"].([]interface{}); got[0] != "users:Get" {
+			t.Fatalf("the caller's statement was modified in place: %v", got)
 		}
 	})
 

--- a/onelogin/resource_onelogin_privileges_plan_test.go
+++ b/onelogin/resource_onelogin_privileges_plan_test.go
@@ -1,0 +1,229 @@
+package onelogin
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	privilegeschema "github.com/onelogin/terraform-provider-onelogin/ol_schema/privilege"
+)
+
+// A perpetual diff is normally only visible in an acceptance test, as "After
+// applying this test step, the plan was not empty" -- which needs credentials
+// and a tenant, and in this resource's case only showed up on the runs where
+// the API happened to return a different order.
+//
+// These tests run the same check offline: build the state privilegeRead would
+// write from a given response, then ask the SDK for a plan against the
+// configuration. What they cannot do is predict the order the API returns, so
+// each one names it explicitly.
+
+// planAfterRead returns the diff a plan produces, given the privilege already
+// in ResourceData -- prior state on a refresh, the configuration at the end of
+// a create or update -- and the statements a read returned.
+func planAfterRead(t *testing.T, prior map[string]interface{}, returned []map[string]interface{}, config map[string]interface{}) *terraform.InstanceDiff {
+	t.Helper()
+	r := Privileges()
+
+	d := r.Data(nil)
+	d.SetId("role_id")
+	if err := d.Set("name", "role_name"); err != nil {
+		t.Fatal(err)
+	}
+	if prior != nil {
+		if err := d.Set("privilege", []map[string]interface{}{prior}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// The write privilegeRead performs, with the HTTP call already made.
+	if err := d.Set("privilege", []map[string]interface{}{{
+		"version":   privilegeschema.DefaultVersion,
+		"statement": privilegeschema.OrderStatementsLikeState(d.Get("privilege"), returned),
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	diff, err := r.Diff(context.Background(), d.State(), terraform.NewResourceConfigRaw(map[string]interface{}{
+		"name":      "role_name",
+		"privilege": []interface{}{config},
+	}), nil)
+	if err != nil {
+		t.Fatalf("diff: %v", err)
+	}
+	return diff
+}
+
+func privilegeDocument(action ...string) map[string]interface{} {
+	return map[string]interface{}{
+		"version":   privilegeschema.DefaultVersion,
+		"statement": []interface{}{privilegeStatement(action...)},
+	}
+}
+
+// privilegeResponse is the statement list privilegeRead builds from the JSON.
+func privilegeResponse(action ...string) []map[string]interface{} {
+	return []map[string]interface{}{privilegeStatement(action...)}
+}
+
+func privilegeStatement(action ...string) map[string]interface{} {
+	acts := make([]interface{}, 0, len(action))
+	for _, a := range action {
+		acts = append(acts, a)
+	}
+	return map[string]interface{}{
+		"effect": "Allow",
+		"action": acts,
+		"scope":  []interface{}{"users/*"},
+	}
+}
+
+func changedAttributes(diff *terraform.InstanceDiff) []string {
+	if diff == nil {
+		return nil
+	}
+	out := make([]string, 0, len(diff.Attributes))
+	for k := range diff.Attributes {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestPrivilegePlanIsEmptyWhenOnlyTheAPIOrderDiffers covers gh-254. The
+// practitioner changed nothing; the API returned the statement's actions in a
+// different order from the one they were written in. action is a TypeList
+// inside a TypeSet, so that changed the privilege element's hash, and the plan
+// proposed removing the whole block and adding it back -- every time, including
+// straight after an apply.
+func TestPrivilegePlanIsEmptyWhenOnlyTheAPIOrderDiffers(t *testing.T) {
+	config := privilegeDocument("users:List", "users:Get")
+	response := privilegeResponse("users:Get", "users:List")
+
+	// Create, update and refresh all reach this with the configuration's order
+	// in ResourceData: the first two because SDK v2 layers the diff over state
+	// and d.Get returns the planned value, refresh because the previous apply
+	// already wrote state in that order.
+	diff := planAfterRead(t, config, response, config)
+	if diff != nil && !diff.Empty() {
+		t.Fatalf("plan was not empty for an unchanged privilege: %v", changedAttributes(diff))
+	}
+}
+
+// TestPrivilegeUpgradeFromApiOrderedState is the path every existing user is
+// on: state was written by a version without the value ordering, so it holds
+// whatever order the API gave. The first plan still proposes a change -- the
+// fix cannot retroactively reorder what is already on disk -- and one apply
+// settles it for good.
+func TestPrivilegeUpgradeFromApiOrderedState(t *testing.T) {
+	config := privilegeDocument("users:List", "users:Get")
+	apiOrder := privilegeDocument("users:Get", "users:List")
+	response := privilegeResponse("users:Get", "users:List")
+
+	// Before the apply: state is in the API's order, so it is matched against
+	// itself and stays there.
+	diff := planAfterRead(t, apiOrder, response, config)
+	if diff == nil || diff.Empty() {
+		t.Fatal("expected the upgrade to plan one change")
+	}
+
+	// The apply's own read has the configuration in ResourceData, so state is
+	// rewritten in the configuration's order and every plan after is empty.
+	if diff = planAfterRead(t, config, response, config); diff != nil && !diff.Empty() {
+		t.Fatalf("did not settle after one apply: %v", changedAttributes(diff))
+	}
+}
+
+// TestPrivilegePlanAgainstRecordedAPIResponse replays the orderings the API
+// actually produced, recorded against the development tenant on 2026-08-10 via
+// POST/GET/PUT /api/1/privileges. The action orderings below are verbatim; the
+// scope is this file's synthetic one, since every recorded statement used "*"
+// and a single-element list cannot demonstrate ordering. Scope reordering is
+// covered at unit level in ol_schema/privilege/statement_order_test.go.
+//
+// Sent, in this order:
+//
+//	statement 0  users:List, users:Get, users:Update, users:Delete
+//	statement 1  apps:List, apps:Get
+//
+// Read back after the create, on four consecutive reads:
+//
+//	statement 0  users:List, users:Delete, users:Get, users:Update
+//	statement 1  apps:List, apps:Get
+//
+// Then the identical document was PUT back, and the next read returned the
+// statements swapped AND the actions in a third order. The same document
+// written twice does not come back the same way, so there is no canonical
+// order to mirror -- only the configuration's order to restore.
+func TestPrivilegePlanAgainstRecordedAPIResponse(t *testing.T) {
+	config := map[string]interface{}{
+		"version": privilegeschema.DefaultVersion,
+		"statement": []interface{}{
+			privilegeStatement("users:List", "users:Get", "users:Update", "users:Delete"),
+			privilegeStatement("apps:List", "apps:Get"),
+		},
+	}
+
+	for _, tc := range []struct {
+		name     string
+		returned []map[string]interface{}
+	}{
+		{
+			"after create: values reordered",
+			[]map[string]interface{}{
+				privilegeStatement("users:List", "users:Delete", "users:Get", "users:Update"),
+				privilegeStatement("apps:List", "apps:Get"),
+			},
+		},
+		{
+			"after update: statements swapped and values reordered again",
+			[]map[string]interface{}{
+				privilegeStatement("apps:Get", "apps:List"),
+				privilegeStatement("users:Update", "users:Get", "users:Delete", "users:List"),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			diff := planAfterRead(t, config, tc.returned, config)
+			if diff != nil && !diff.Empty() {
+				t.Fatalf("plan was not empty for an unchanged privilege: %v", changedAttributes(diff))
+			}
+		})
+	}
+}
+
+// A real edit must still plan, or the fix above would be hiding changes rather
+// than settling them.
+func TestPrivilegePlanDetectsRealChanges(t *testing.T) {
+	prior := privilegeDocument("users:List", "users:Get")
+	response := privilegeResponse("users:Get", "users:List")
+
+	for _, tc := range []struct {
+		name   string
+		config map[string]interface{}
+	}{
+		{"an action added", privilegeDocument("users:List", "users:Get", "users:Delete")},
+		{"an action removed", privilegeDocument("users:List")},
+		{"an action swapped", privilegeDocument("users:List", "users:Update")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			diff := planAfterRead(t, prior, response, tc.config)
+			if diff == nil || diff.Empty() {
+				t.Fatal("a real change produced an empty plan")
+			}
+		})
+	}
+}
+
+// On import there is no prior order to respond to, so the API's order reaches
+// state and the first plan proposes a change. One apply settles it, which is
+// the same bargain the statement ordering already makes.
+func TestPrivilegePlanAfterImport(t *testing.T) {
+	config := privilegeDocument("users:List", "users:Get")
+
+	diff := planAfterRead(t, nil, privilegeResponse("users:Get", "users:List"), config)
+	if diff == nil || diff.Empty() {
+		t.Fatal("expected import to plan the one-time change")
+	}
+}

--- a/onelogin/resource_onelogin_privileges_test.go
+++ b/onelogin/resource_onelogin_privileges_test.go
@@ -6,6 +6,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
+// The fixtures deliberately give one statement SEVERAL actions, listed out of
+// alphabetical order. The API returns the values inside a statement in an order
+// of its own, and a single-action statement cannot express that -- which is why
+// this test passed throughout gh-254. Do not simplify them back to one action.
 func TestAccPrivilege_crud(t *testing.T) {
 	// One suffix across both steps: loaded separately, step 2 would get a
 	// different one and replace every resource instead of updating them.
@@ -28,9 +32,15 @@ func TestAccPrivilege_crud(t *testing.T) {
 					// rather than index: "privilege.statement.0..." can never
 					// match. TestCheckTypeSetElemNestedAttrs searches the set.
 					resource.TestCheckResourceAttr("onelogin_privileges.super_admin", "privilege.#", "1"),
+					// The full action list, in the order the configuration
+					// declares it. Asserting only element 0 cannot see the
+					// reordering the API applies inside a statement.
 					resource.TestCheckTypeSetElemNestedAttrs("onelogin_privileges.super_admin", "privilege.*", map[string]string{
 						"statement.0.action.0": "apps:List",
 						"statement.1.action.0": "users:List",
+						"statement.1.action.1": "users:Get",
+						"statement.1.action.2": "users:Update",
+						"statement.1.action.3": "users:Delete",
 					}),
 				),
 			},
@@ -43,6 +53,9 @@ func TestAccPrivilege_crud(t *testing.T) {
 					resource.TestCheckTypeSetElemNestedAttrs("onelogin_privileges.super_admin", "privilege.*", map[string]string{
 						"statement.0.action.0": "apps:List",
 						"statement.1.action.0": "users:List",
+						"statement.1.action.1": "users:Get",
+						"statement.1.action.2": "users:Update",
+						"statement.1.action.3": "users:Delete",
 					}),
 				),
 			},


### PR DESCRIPTION
Fixes #254.

## Problem

Every plan on a `onelogin_privileges` block proposes removing the whole `privilege` block and adding it back, with nothing changed. Applying twice reproduces it.

## Cause

The API does not preserve the order of the `Action` and `Scope` values *inside* a statement. `action` and `scope` are `TypeList`s (order-sensitive) nested inside `privilege`, which is a `TypeSet` whose default hash covers every nested value **including list order**. A transposed pair changes the element's hash, so Terraform cannot match the set element and renders a whole-block remove + add rather than an in-place edit — which is why the plan looks far more alarming than "two strings are the wrong way round".

v1.0.0 already fixed this one level up, for the *statement list*. That fix stopped there on an assumption written into the code and into a test:

```go
// Untouched is safe: unlike the statements themselves, the API preserves the
// order of the values inside one.
```

That assumption is wrong.

## Verified against the API

Recorded against the development tenant via `POST`/`GET`/`PUT /api/1/privileges`:

```
SENT           stmt0  users:List, users:Get, users:Update, users:Delete
GET x4         stmt0  users:List, users:Delete, users:Get, users:Update

PUT the identical document back, then read:
               stmt0  apps:Get, apps:List                                  <- statements swapped
               stmt1  users:Update, users:Get, users:Delete, users:List     <- a third ordering
```

The same document written twice comes back differently, so this is not a stable canonicalisation that could be mirrored. Sorting the response does not help either — the practitioner's config is unsorted, so sorted state still diffs. The only stable reference is the order the configuration already has.

## Fix

Extend the existing prior-state technique down one level: when a returned statement matches one already in state, put its `action` and `scope` values back into that order. Non-breaking — no schema change, no state addressing change.

Safety properties:

- `statementKey` covers the whole *sorted* action and scope sets, so only genuinely identical statements are ever reordered. A statement that gained, lost or swapped a value does not match and is written through untouched, so real changes still plan.
- `orderLikePrior` provably emits a **permutation** of what the API returned — it can neither invent nor drop a value. Even a hypothetical false match could only produce an odd order, never wrong data.

## Why the tests did not catch this

Every statement in the acceptance fixture had exactly one action, and a one-element list cannot be reordered — so `TestAccPrivilege_crud` was structurally blind to this entire class of bug and passed throughout. Asserting only `action.0` had the same blind spot.

The fixture now has a four-action statement in non-alphabetical order and the checks cover the whole list. Against the development tenant:

| | without fix | with fix |
|---|---|---|
| old fixture (1 action) | PASS x3 — blind | PASS x3 |
| new fixture (4 actions) | **FAIL x3** | **PASS x3** |

This PR also adds plan-level tests that catch a perpetual diff **offline**, in milliseconds, with no credentials or tenant — previously this only surfaced as "the plan was not empty" in an acceptance run. Worth having for any resource with this shape; there are others.

## Upgrade note

Anyone whose state was written by an earlier version holds the API's order on disk, so **the first plan after upgrading proposes one change, and one apply settles it.** The same is true on import. This is the bargain the statement-level ordering already made; `TestPrivilegeUpgradeFromApiOrderedState` pins it.

## Testing

- Unit suite: 24 packages green, `go vet` and `gofmt` clean.
- Acceptance `TestAccPrivilege_crud` against a development tenant: 3/3 pass with the fix, 3/3 fail without.
- Every new test fails without the fix, for the right reason.
